### PR TITLE
24 side by side chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 vendor/
 .env
-*.csv
-/web/data/*

--- a/web/data/cricket-captains.csv
+++ b/web/data/cricket-captains.csv
@@ -1,0 +1,3215 @@
+Team,Result,Margin,BR,Toss,Bat,Opposition,Ground,Date,Captain
+Australia,tied,-,0,lost,1st,England,Lord's,7/2/2005,
+Australia,tied,-,0,lost,1st,South Africa,Birmingham,6/17/1999,
+Australia,tied,-,0,lost,2nd,South Africa,Melbourne (Docklands),8/18/2000,
+Australia,tied,-,0,lost,2nd,South Africa,Potchefstroom,3/27/2002,
+Australia,tied,-,0,won,1st,West Indies,Kingstown,3/20/2012,
+Australia,tied,-,0,won,2nd,West Indies,Georgetown,4/21/1999,
+England,tied,-,0,lost,1st,New Zealand,Napier,2/20/2008,Daniel Vettori (NZ)
+England,tied,-,0,lost,1st,South Africa,Bloemfontein,2/2/2005,
+England,tied,-,0,lost,2nd,India,Bangalore,2/27/2011,
+England,tied,-,0,lost,2nd,New Zealand,Napier,2/26/1997,Lee Germon (NZ)
+England,tied,-,0,won,2nd,Australia,Lord's,7/2/2005,
+England,tied,-,0,won,2nd,India,Lord's,9/11/2011,
+India,tied,-,0,lost,1st,England,Lord's,9/11/2011,
+India,tied,-,0,lost,2nd,Sri Lanka,Adelaide,2/14/2012,
+India,tied,-,0,won,1st,England,Bangalore,2/27/2011,
+India,tied,-,0,won,2nd,New Zealand,Auckland,1/25/2014,Brendon McCullum (NZ)
+New Zealand,tied,-,0,lost,1st,India,Auckland,1/25/2014,Brendon McCullum (NZ)
+New Zealand,tied,-,0,won,1st,England,Napier,2/26/1997,Lee Germon (NZ)
+New Zealand,tied,-,0,won,1st,Sri Lanka,Sharjah,11/11/1996,Lee Germon (NZ)
+New Zealand,tied,-,0,won,2nd,England,Napier,2/20/2008,Daniel Vettori (NZ)
+Pakistan,tied,-,0,lost,1st,West Indies,Gros Islet,7/19/2013,
+Pakistan,tied,-,0,won,1st,Sri Lanka,Sharjah,10/15/1999,
+South Africa,tied,-,0,lost,1st,West Indies,Cardiff,6/14/2013,
+South Africa,tied,-,0,lost,2nd,Sri Lanka,Durban,3/3/2003,
+South Africa,tied,-,0,won,1st,Australia,Melbourne (Docklands),8/18/2000,
+South Africa,tied,-,0,won,1st,Australia,Potchefstroom,3/27/2002,
+South Africa,tied,-,0,won,2nd,Australia,Birmingham,6/17/1999,
+South Africa,tied,-,0,won,2nd,England,Bloemfontein,2/2/2005,
+Sri Lanka,tied,-,0,lost,2nd,New Zealand,Sharjah,11/11/1996,Lee Germon (NZ)
+Sri Lanka,tied,-,0,lost,2nd,Pakistan,Sharjah,10/15/1999,
+Sri Lanka,tied,-,0,won,1st,India,Adelaide,2/14/2012,
+Sri Lanka,tied,-,0,won,1st,South Africa,Durban,3/3/2003,
+West Indies,tied,-,0,lost,1st,Australia,Georgetown,4/21/1999,
+West Indies,tied,-,0,lost,2nd,Australia,Kingstown,3/20/2012,
+West Indies,tied,-,0,won,2nd,Pakistan,Gros Islet,7/19/2013,
+West Indies,tied,-,0,won,2nd,South Africa,Cardiff,6/14/2013,
+Australia,lost,1 runs,0,lost,2nd,Sri Lanka,Dambulla,2/22/2004,
+Australia,won,1 runs,0,lost,1st,West Indies,Basseterre,7/4/2008,
+Australia,won,1 runs,0,won,1st,Pakistan,Abu Dhabi,10/12/2014,
+England,lost,1 runs,0,lost,2nd,South Africa,Cape Town,1/26/2000,
+England,won,1 runs,0,won,1st,West Indies,Providence,3/20/2009,
+India,lost,1 runs,0,won,2nd,West Indies,Kingston,5/20/2006,
+India,won,1 runs,0,lost,1st,South Africa,Jaipur,2/21/2010,
+India,won,1 runs,0,won,1st,South Africa,Johannesburg,1/15/2011,
+New Zealand,lost,1 runs,0,lost,2nd,South Africa,Hobart,12/11/1997,Stephen Fleming (NZ)
+Pakistan,lost,1 runs,0,lost,1st,West Indies,Bridgetown,5/2/2011,
+Pakistan,lost,1 runs,0,lost,2nd,Australia,Abu Dhabi,10/12/2014,
+Pakistan,lost,1 runs,0,lost,2nd,South Africa,Sharjah,10/30/2013,
+Pakistan,won,1 runs,0,lost,1st,South Africa,Port Elizabeth,11/27/2013,
+South Africa,lost,1 runs,0,lost,2nd,India,Johannesburg,1/15/2011,
+South Africa,lost,1 runs,0,won,2nd,India,Jaipur,2/21/2010,
+South Africa,lost,1 runs,0,won,2nd,Pakistan,Port Elizabeth,11/27/2013,
+South Africa,won,1 runs,0,lost,1st,West Indies,Bridgetown,5/11/2005,
+South Africa,won,1 runs,0,won,1st,England,Cape Town,1/26/2000,
+South Africa,won,1 runs,0,won,1st,New Zealand,Hobart,12/11/1997,Stephen Fleming (NZ)
+South Africa,won,1 runs,0,won,1st,Pakistan,Sharjah,10/30/2013,
+Sri Lanka,won,1 runs,0,won,1st,Australia,Dambulla,2/22/2004,
+West Indies,lost,1 runs,0,lost,2nd,England,Providence,3/20/2009,
+West Indies,lost,1 runs,0,won,2nd,Australia,Basseterre,7/4/2008,
+West Indies,lost,1 runs,0,won,2nd,South Africa,Bridgetown,5/11/2005,
+West Indies,won,1 runs,0,lost,1st,India,Kingston,5/20/2006,
+West Indies,won,1 runs,0,won,2nd,Pakistan,Bridgetown,5/2/2011,
+England,lost,1 wickets,0,lost,1st,New Zealand,The Oval,6/25/2008,Daniel Vettori (NZ)
+New Zealand,lost,1 wickets,0,won,1st,South Africa,Potchefstroom,1/25/2013,Brendon McCullum (NZ)
+New Zealand,won,1 wickets,0,won,2nd,England,The Oval,6/25/2008,Daniel Vettori (NZ)
+New Zealand,won,1 wickets,0,won,2nd,Sri Lanka,Queenstown,12/31/2006,Daniel Vettori (NZ)
+South Africa,won,1 wickets,0,lost,2nd,New Zealand,Potchefstroom,1/25/2013,Brendon McCullum (NZ)
+Sri Lanka,lost,1 wickets,0,lost,1st,New Zealand,Queenstown,12/31/2006,Daniel Vettori (NZ)
+Sri Lanka,lost,1 wickets,0,lost,1st,West Indies,Port of Spain,4/10/2008,
+West Indies,won,1 wickets,0,won,2nd,Sri Lanka,Port of Spain,4/10/2008,
+Australia,lost,1 wickets,1,won,1st,South Africa,Johannesburg,3/12/2006,
+England,lost,1 wickets,1,lost,1st,West Indies,Bridgetown,4/1/1998,
+England,won,1 wickets,1,won,2nd,West Indies,Bridgetown,4/21/2007,
+India,won,1 wickets,1,won,2nd,New Zealand,Auckland,1/11/2003,Stephen Fleming (NZ)
+New Zealand,lost,1 wickets,1,lost,1st,India,Auckland,1/11/2003,Stephen Fleming (NZ)
+Pakistan,won,1 wickets,1,lost,2nd,South Africa,Abu Dhabi,10/31/2010,
+Pakistan,won,1 wickets,1,lost,2nd,South Africa,Dubai (DSC),11/5/2010,
+South Africa,lost,1 wickets,1,won,1st,Pakistan,Abu Dhabi,10/31/2010,
+South Africa,lost,1 wickets,1,won,1st,Pakistan,Dubai (DSC),11/5/2010,
+South Africa,won,1 wickets,1,lost,2nd,Australia,Johannesburg,3/12/2006,
+West Indies,lost,1 wickets,1,lost,1st,England,Bridgetown,4/21/2007,
+West Indies,won,1 wickets,1,won,2nd,England,Bridgetown,4/1/1998,
+England,lost,1 wickets,2,lost,1st,Sri Lanka,Adelaide,1/23/1999,
+India,lost,1 wickets,2,lost,1st,Pakistan,Dhaka,3/2/2014,
+India,won,1 wickets,2,won,2nd,Sri Lanka,Port of Spain,7/11/2013,
+Pakistan,won,1 wickets,2,won,2nd,India,Dhaka,3/2/2014,
+South Africa,won,1 wickets,2,lost,2nd,West Indies,Port of Spain,6/3/2010,
+Sri Lanka,lost,1 wickets,2,lost,1st,India,Port of Spain,7/11/2013,
+Sri Lanka,won,1 wickets,2,won,2nd,England,Adelaide,1/23/1999,
+West Indies,lost,1 wickets,2,won,1st,South Africa,Port of Spain,6/3/2010,
+Australia,lost,1 wickets,3,won,1st,New Zealand,Hamilton,2/20/2007,Stephen Fleming (NZ)
+Australia,won,1 wickets,3,lost,2nd,England,Brisbane,1/17/2014,
+England,lost,1 wickets,3,won,1st,Australia,Brisbane,1/17/2014,
+New Zealand,won,1 wickets,3,lost,2nd,Australia,Hamilton,2/20/2007,Stephen Fleming (NZ)
+Australia,lost,1 wickets,5,lost,1st,England,Manchester,6/27/2010,
+Australia,won,1 wickets,5,lost,2nd,South Africa,Durban,3/10/2006,
+England,won,1 wickets,5,won,2nd,Australia,Manchester,6/27/2010,
+New Zealand,lost,1 wickets,5,lost,1st,West Indies,Kingston,3/26/1996,Lee Germon (NZ)
+South Africa,lost,1 wickets,5,won,1st,Australia,Durban,3/10/2006,
+West Indies,won,1 wickets,5,won,2nd,New Zealand,Kingston,3/26/1996,Lee Germon (NZ)
+India,won,1 wickets,7,won,2nd,West Indies,Cuttack,11/29/2011,
+Sri Lanka,won,1 wickets,7,won,2nd,West Indies,Colombo (RPS),11/1/2015,
+West Indies,lost,1 wickets,7,lost,1st,India,Cuttack,11/29/2011,
+West Indies,lost,1 wickets,7,lost,1st,Sri Lanka,Colombo (RPS),11/1/2015,
+South Africa,lost,1 wickets,9,lost,1st,West Indies,Port Elizabeth,1/25/2015,
+West Indies,won,1 wickets,9,won,2nd,South Africa,Port Elizabeth,1/25/2015,
+South Africa,won,1 wickets,10,lost,2nd,Sri Lanka,Providence,3/28/2007,
+Sri Lanka,lost,1 wickets,10,won,1st,South Africa,Providence,3/28/2007,
+India,lost,1 wickets,14,lost,1st,West Indies,Kingston,6/30/2013,
+West Indies,won,1 wickets,14,won,2nd,India,Kingston,6/30/2013,
+New Zealand,won,1 wickets,26,won,2nd,South Africa,Paarl,1/19/2013,Brendon McCullum (NZ)
+South Africa,lost,1 wickets,26,lost,1st,New Zealand,Paarl,1/19/2013,Brendon McCullum (NZ)
+Australia,lost,1 wickets,34,won,1st,Sri Lanka,Melbourne,11/3/2010,
+Sri Lanka,won,1 wickets,34,lost,2nd,Australia,Melbourne,11/3/2010,
+New Zealand,won,1 wickets,81,lost,2nd,Sri Lanka,Cardiff,6/9/2013,Brendon McCullum (NZ)
+Sri Lanka,lost,1 wickets,81,won,1st,New Zealand,Cardiff,6/9/2013,Brendon McCullum (NZ)
+Australia,lost,1 wickets,161,won,1st,New Zealand,Auckland,2/28/2015,Brendon McCullum (NZ)
+New Zealand,won,1 wickets,161,lost,2nd,Australia,Auckland,2/28/2015,Brendon McCullum (NZ)
+Australia,lost,10 runs,0,lost,2nd,West Indies,Mumbai (BS),10/18/2006,
+Australia,lost,10 runs,0,won,2nd,Pakistan,Leeds,5/23/1999,
+Australia,won,10 runs,0,lost,1st,Pakistan,Lord's,9/4/2004,
+Australia,won,10 runs,0,won,1st,England,Sydney,2/10/1999,
+Australia,won,10 runs,0,won,1st,New Zealand,Wellington,2/19/2005,Stephen Fleming (NZ)
+England,lost,10 runs,0,lost,2nd,Australia,Sydney,2/10/1999,
+England,won,10 runs,0,lost,1st,New Zealand,Cardiff,6/16/2013,Brendon McCullum (NZ)
+India,lost,10 runs,0,won,2nd,South Africa,Nagpur,3/19/2000,
+India,won,10 runs,0,won,1st,Pakistan,Delhi,1/6/2013,
+India,won,10 runs,0,won,1st,South Africa,Colombo (RPS),9/25/2002,
+New Zealand,lost,10 runs,0,lost,2nd,Australia,Wellington,2/19/2005,Stephen Fleming (NZ)
+New Zealand,lost,10 runs,0,won,2nd,England,Cardiff,6/16/2013,Brendon McCullum (NZ)
+Pakistan,lost,10 runs,0,lost,2nd,India,Delhi,1/6/2013,
+Pakistan,lost,10 runs,0,won,2nd,Australia,Lord's,9/4/2004,
+Pakistan,won,10 runs,0,lost,1st,Australia,Leeds,5/23/1999,
+South Africa,lost,10 runs,0,lost,2nd,India,Colombo (RPS),9/25/2002,
+South Africa,won,10 runs,0,lost,1st,India,Nagpur,3/19/2000,
+West Indies,won,10 runs,0,won,1st,Australia,Mumbai (BS),10/18/2006,
+India,lost,10 wickets,32,lost,1st,West Indies,Bridgetown,5/3/1997,
+West Indies,won,10 wickets,32,won,2nd,India,Bridgetown,5/3/1997,
+England,lost,10 wickets,63,won,1st,Sri Lanka,Colombo (RPS),3/26/2011,
+Sri Lanka,won,10 wickets,63,lost,2nd,England,Colombo (RPS),3/26/2011,
+India,lost,10 wickets,85,lost,1st,South Africa,Kolkata,11/25/2005,
+South Africa,won,10 wickets,85,won,2nd,India,Kolkata,11/25/2005,
+England,won,10 wickets,88,won,2nd,West Indies,Chester-le-Street,7/15/2000,
+West Indies,lost,10 wickets,88,lost,1st,England,Chester-le-Street,7/15/2000,
+England,lost,10 wickets,97,lost,1st,Sri Lanka,Colombo (SSC),3/27/2001,
+Sri Lanka,won,10 wickets,97,won,2nd,England,Colombo (SSC),3/27/2001,
+India,won,10 wickets,101,won,2nd,West Indies,Port of Spain,4/27/1997,
+West Indies,lost,10 wickets,101,lost,1st,India,Port of Spain,4/27/1997,
+England,lost,10 wickets,107,lost,1st,New Zealand,Hamilton,2/12/2008,Daniel Vettori (NZ)
+New Zealand,won,10 wickets,107,won,2nd,England,Hamilton,2/12/2008,Daniel Vettori (NZ)
+India,lost,10 wickets,124,won,1st,South Africa,Sharjah,3/22/2000,
+South Africa,won,10 wickets,124,lost,2nd,India,Sharjah,3/22/2000,
+Australia,lost,10 wickets,138,lost,1st,New Zealand,Wellington,2/16/2007,Stephen Fleming (NZ)
+New Zealand,won,10 wickets,138,won,2nd,Australia,Wellington,2/16/2007,Stephen Fleming (NZ)
+England,won,10 wickets,145,won,2nd,Sri Lanka,Nottingham,7/6/2011,
+Sri Lanka,lost,10 wickets,145,lost,1st,England,Nottingham,7/6/2011,
+Pakistan,lost,10 wickets,159,won,1st,West Indies,Providence,5/5/2011,
+West Indies,won,10 wickets,159,lost,2nd,Pakistan,Providence,5/5/2011,
+Australia,won,10 wickets,163,lost,2nd,West Indies,Adelaide,1/26/2001,
+West Indies,lost,10 wickets,163,won,1st,Australia,Adelaide,1/26/2001,
+Pakistan,won,10 wickets,175,lost,2nd,West Indies,Dhaka,3/23/2011,
+West Indies,lost,10 wickets,175,won,1st,Pakistan,Dhaka,3/23/2011,
+England,won,10 wickets,215,lost,2nd,South Africa,Nottingham,8/26/2008,
+South Africa,lost,10 wickets,215,won,1st,England,Nottingham,8/26/2008,
+Pakistan,lost,10 wickets,216,lost,1st,South Africa,Cape Town,2/11/2007,
+South Africa,won,10 wickets,216,won,2nd,Pakistan,Cape Town,2/11/2007,
+England,lost,10 wickets,217,won,1st,Sri Lanka,Dambulla,11/18/2003,
+Sri Lanka,won,10 wickets,217,lost,2nd,England,Dambulla,11/18/2003,
+Australia,won,10 wickets,226,lost,2nd,England,Sydney,1/23/2003,
+England,lost,10 wickets,226,won,1st,Australia,Sydney,1/23/2003,
+England,won,10 wickets,227,won,2nd,Sri Lanka,Manchester,5/28/2014,
+Sri Lanka,lost,10 wickets,227,lost,1st,England,Manchester,5/28/2014,
+New Zealand,won,10 wickets,250,lost,2nd,Sri Lanka,Christchurch,12/28/2015,Brendon McCullum (NZ)
+Sri Lanka,lost,10 wickets,250,won,1st,New Zealand,Christchurch,12/28/2015,Brendon McCullum (NZ)
+India,lost,100 runs,0,won,2nd,Sri Lanka,Karachi,7/6/2008,
+Sri Lanka,won,100 runs,0,lost,1st,India,Karachi,7/6/2008,
+India,won,102 runs,0,lost,1st,West Indies,Port of Spain,7/5/2013,
+West Indies,lost,102 runs,0,won,2nd,India,Port of Spain,7/5/2013,
+Australia,won,103 runs,0,lost,1st,West Indies,North Sound,3/27/2007,
+India,lost,103 runs,0,won,2nd,West Indies,North Sound,6/13/2011,
+West Indies,lost,103 runs,0,won,2nd,Australia,North Sound,3/27/2007,
+West Indies,won,103 runs,0,lost,1st,India,North Sound,6/13/2011,
+England,won,104 runs,0,lost,1st,India,Southampton,8/21/2007,
+India,lost,104 runs,0,lost,2nd,Pakistan,Perth,1/28/2000,
+India,lost,104 runs,0,won,2nd,England,Southampton,8/21/2007,
+Pakistan,lost,104 runs,0,won,2nd,Sri Lanka,Lahore,2/19/2000,
+Pakistan,won,104 runs,0,won,1st,India,Perth,1/28/2000,
+Sri Lanka,won,104 runs,0,lost,1st,Pakistan,Lahore,2/19/2000,
+Australia,won,105 runs,0,won,1st,New Zealand,Hobart,1/14/2007,Stephen Fleming (NZ)
+India,won,105 runs,0,won,1st,New Zealand,Dambulla,8/25/2010,Ross Taylor (NZ)
+New Zealand,lost,105 runs,0,lost,2nd,Australia,Hobart,1/14/2007,Stephen Fleming (NZ)
+New Zealand,lost,105 runs,0,lost,2nd,India,Dambulla,8/25/2010,Ross Taylor (NZ)
+Australia,won,106 runs,0,lost,1st,New Zealand,Christchurch,2/22/2005,Stephen Fleming (NZ)
+India,lost,106 runs,0,lost,2nd,Pakistan,Jamshedpur,4/9/2005,
+India,lost,106 runs,0,lost,2nd,South Africa,Cape Town,11/26/2006,
+New Zealand,lost,106 runs,0,lost,2nd,Sri Lanka,Sharjah,4/10/2001,
+New Zealand,lost,106 runs,0,won,2nd,Australia,Christchurch,2/22/2005,Stephen Fleming (NZ)
+New Zealand,lost,106 runs,0,won,2nd,Sri Lanka,Colombo (SSC),7/31/2001,Stephen Fleming (NZ)
+Pakistan,won,106 runs,0,won,1st,India,Jamshedpur,4/9/2005,
+South Africa,won,106 runs,0,won,1st,India,Cape Town,11/26/2006,
+Sri Lanka,won,106 runs,0,lost,1st,New Zealand,Colombo (SSC),7/31/2001,Stephen Fleming (NZ)
+Sri Lanka,won,106 runs,0,won,1st,New Zealand,Sharjah,4/10/2001,
+Australia,won,107 runs,0,won,1st,Sri Lanka,Melbourne,1/11/2013,
+England,lost,107 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),10/13/2007,
+England,won,107 runs,0,lost,1st,Pakistan,Birmingham,8/31/1996,
+New Zealand,won,107 runs,0,lost,1st,West Indies,Lord's,7/10/2004,Stephen Fleming (NZ)
+Pakistan,lost,107 runs,0,won,2nd,England,Birmingham,8/31/1996,
+Sri Lanka,lost,107 runs,0,lost,2nd,Australia,Melbourne,1/11/2013,
+Sri Lanka,won,107 runs,0,won,1st,England,Colombo (RPS),10/13/2007,
+West Indies,lost,107 runs,0,won,2nd,New Zealand,Lord's,7/10/2004,Stephen Fleming (NZ)
+England,lost,108 runs,0,lost,2nd,Pakistan,Birmingham,6/7/2001,
+England,lost,108 runs,0,won,2nd,South Africa,Cape Town,2/6/2005,
+New Zealand,won,108 runs,0,lost,1st,Sri Lanka,Dunedin,1/23/2015,Brendon McCullum (NZ)
+Pakistan,won,108 runs,0,won,1st,England,Birmingham,6/7/2001,
+South Africa,won,108 runs,0,lost,1st,England,Cape Town,2/6/2005,
+Sri Lanka,lost,108 runs,0,won,2nd,New Zealand,Dunedin,1/23/2015,Brendon McCullum (NZ)
+Sri Lanka,won,108 runs,0,lost,1st,West Indies,Nairobi (Gym),10/4/2000,
+West Indies,lost,108 runs,0,won,2nd,Sri Lanka,Nairobi (Gym),10/4/2000,
+Australia,lost,109 runs,0,won,2nd,South Africa,Bloemfontein,4/13/1997,
+South Africa,won,109 runs,0,lost,1st,Australia,Bloemfontein,4/13/1997,
+England,lost,11 runs,0,won,2nd,New Zealand,Ahmedabad,2/14/1996,Lee Germon (NZ)
+England,lost,11 runs,0,won,2nd,Sri Lanka,Sydney,2/3/1999,
+New Zealand,lost,11 runs,0,lost,2nd,Pakistan,Gujranwala,12/4/1996,Lee Germon (NZ)
+New Zealand,won,11 runs,0,lost,1st,England,Ahmedabad,2/14/1996,Lee Germon (NZ)
+New Zealand,won,11 runs,0,won,1st,Sri Lanka,Sharjah,4/9/2002,Stephen Fleming (NZ)
+Pakistan,won,11 runs,0,won,1st,New Zealand,Gujranwala,12/4/1996,Lee Germon (NZ)
+Pakistan,won,11 runs,0,won,1st,Sri Lanka,Colombo (RPS),2/26/2011,
+Pakistan,won,11 runs,0,won,1st,Sri Lanka,Sharjah,12/18/2013,
+Sri Lanka,lost,11 runs,0,lost,2nd,New Zealand,Sharjah,4/9/2002,Stephen Fleming (NZ)
+Sri Lanka,lost,11 runs,0,lost,2nd,Pakistan,Colombo (RPS),2/26/2011,
+Sri Lanka,lost,11 runs,0,lost,2nd,Pakistan,Sharjah,12/18/2013,
+Sri Lanka,won,11 runs,0,lost,1st,England,Sydney,2/3/1999,
+Australia,won,110 runs,0,won,1st,India,Brisbane,2/19/2012,
+England,won,110 runs,0,lost,1st,Sri Lanka,The Oval,6/28/2011,
+India,lost,110 runs,0,lost,2nd,Australia,Brisbane,2/19/2012,
+New Zealand,won,110 runs,0,won,1st,Pakistan,Pallekele,3/8/2011,Daniel Vettori (NZ)
+Pakistan,lost,110 runs,0,lost,2nd,New Zealand,Pallekele,3/8/2011,Daniel Vettori (NZ)
+Pakistan,lost,110 runs,0,lost,2nd,West Indies,Sharjah,2/17/2002,
+Pakistan,won,110 runs,0,won,1st,Sri Lanka,Paarl,4/9/1998,
+Sri Lanka,lost,110 runs,0,lost,2nd,Pakistan,Paarl,4/9/1998,
+Sri Lanka,lost,110 runs,0,won,2nd,England,The Oval,6/28/2011,
+West Indies,won,110 runs,0,won,1st,Pakistan,Sharjah,2/17/2002,
+Australia,won,111 runs,0,lost,1st,England,Melbourne,2/14/2015,
+Australia,won,111 runs,0,won,1st,England,Nottingham,9/17/2009,
+England,lost,111 runs,0,lost,2nd,Australia,Nottingham,9/17/2009,
+England,lost,111 runs,0,won,2nd,Australia,Melbourne,2/14/2015,
+Australia,won,112 runs,0,lost,1st,England,Perth,2/1/2015,
+England,lost,112 runs,0,lost,2nd,South Africa,Cape Town,11/27/2009,
+England,lost,112 runs,0,won,2nd,Australia,Perth,2/1/2015,
+England,won,112 runs,0,won,1st,Pakistan,Cape Town,2/22/2003,
+India,lost,112 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),8/29/2008,
+New Zealand,lost,112 runs,0,lost,2nd,Sri Lanka,Mumbai,3/18/2011,Ross Taylor (NZ)
+Pakistan,lost,112 runs,0,lost,2nd,England,Cape Town,2/22/2003,
+South Africa,won,112 runs,0,won,1st,England,Cape Town,11/27/2009,
+Sri Lanka,won,112 runs,0,won,1st,India,Colombo (RPS),8/29/2008,
+Sri Lanka,won,112 runs,0,won,1st,New Zealand,Mumbai,3/18/2011,Ross Taylor (NZ)
+Australia,won,113 runs,0,lost,1st,West Indies,Melbourne,2/7/2010,
+Pakistan,won,113 runs,0,lost,1st,Sri Lanka,Sharjah,12/22/2013,
+Sri Lanka,lost,113 runs,0,won,2nd,Pakistan,Sharjah,12/22/2013,
+Sri Lanka,won,113 runs,0,lost,1st,West Indies,Providence,4/1/2007,
+West Indies,lost,113 runs,0,won,2nd,Australia,Melbourne,2/7/2010,
+West Indies,lost,113 runs,0,won,2nd,Sri Lanka,Providence,4/1/2007,
+Australia,won,114 runs,0,lost,1st,New Zealand,Hobart,12/20/2007,Daniel Vettori (NZ)
+England,won,114 runs,0,lost,1st,New Zealand,Chester-le-Street,6/15/2008,Daniel Vettori (NZ)
+England,won,114 runs,0,lost,1st,West Indies,Southampton,6/16/2012,
+New Zealand,lost,114 runs,0,won,2nd,Australia,Hobart,12/20/2007,Daniel Vettori (NZ)
+New Zealand,lost,114 runs,0,won,2nd,England,Chester-le-Street,6/15/2008,Daniel Vettori (NZ)
+South Africa,won,114 runs,0,won,1st,West Indies,Bloemfontein,2/5/1999,
+West Indies,lost,114 runs,0,lost,2nd,South Africa,Bloemfontein,2/5/1999,
+West Indies,lost,114 runs,0,won,2nd,England,Southampton,6/16/2012,
+New Zealand,lost,115 runs,0,won,2nd,South Africa,Centurion,10/25/2000,Stephen Fleming (NZ)
+Pakistan,lost,115 runs,0,lost,2nd,Sri Lanka,Abu Dhabi,5/22/2007,
+Pakistan,lost,115 runs,0,lost,2nd,Sri Lanka,Mohali,5/24/1997,
+Pakistan,lost,115 runs,0,won,2nd,Sri Lanka,Benoni,4/15/1998,
+South Africa,won,115 runs,0,lost,1st,New Zealand,Centurion,10/25/2000,Stephen Fleming (NZ)
+Sri Lanka,won,115 runs,0,lost,1st,Pakistan,Benoni,4/15/1998,
+Sri Lanka,won,115 runs,0,won,1st,Pakistan,Abu Dhabi,5/22/2007,
+Sri Lanka,won,115 runs,0,won,1st,Pakistan,Mohali,5/24/1997,
+Australia,won,116 runs,0,lost,1st,Sri Lanka,Melbourne (Docklands),1/13/2006,
+Australia,won,116 runs,0,won,1st,West Indies,Melbourne,1/14/2005,
+India,lost,116 runs,0,lost,2nd,Pakistan,Sharjah,4/8/1999,
+Pakistan,won,116 runs,0,won,1st,India,Sharjah,4/8/1999,
+Sri Lanka,lost,116 runs,0,won,2nd,Australia,Melbourne (Docklands),1/13/2006,
+West Indies,lost,116 runs,0,lost,2nd,Australia,Melbourne,1/14/2005,
+Pakistan,lost,117 runs,0,lost,2nd,South Africa,Sharjah,11/11/2013,
+South Africa,won,117 runs,0,won,1st,Pakistan,Sharjah,11/11/2013,
+Australia,lost,118 runs,0,won,2nd,India,Indore,3/31/2001,
+India,won,118 runs,0,lost,1st,Australia,Indore,3/31/2001,
+Pakistan,won,118 runs,0,won,1st,Sri Lanka,Sharjah,10/18/1999,
+Sri Lanka,lost,118 runs,0,lost,2nd,Pakistan,Sharjah,10/18/1999,
+England,lost,119 runs,0,lost,2nd,Sri Lanka,Dambulla,10/1/2007,
+New Zealand,won,119 runs,0,won,1st,Pakistan,Napier,2/3/2015,Brendon McCullum (NZ)
+Pakistan,lost,119 runs,0,lost,2nd,New Zealand,Napier,2/3/2015,Brendon McCullum (NZ)
+Pakistan,lost,119 runs,0,won,2nd,Sri Lanka,Lahore,10/16/2004,
+Sri Lanka,won,119 runs,0,lost,1st,Pakistan,Lahore,10/16/2004,
+Sri Lanka,won,119 runs,0,won,1st,England,Dambulla,10/1/2007,
+Australia,lost,12 runs,0,lost,2nd,Pakistan,Adelaide,12/15/1996,
+Australia,won,12 runs,0,won,1st,New Zealand,Auckland,3/6/2010,Daniel Vettori (NZ)
+India,lost,12 runs,0,lost,2nd,Pakistan,Rawalpindi,3/16/2004,
+India,lost,12 runs,0,lost,2nd,Sri Lanka,Dambulla,7/18/2004,
+India,won,12 runs,0,won,1st,Sri Lanka,Singapore,4/3/1996,
+New Zealand,lost,12 runs,0,lost,2nd,Australia,Auckland,3/6/2010,Daniel Vettori (NZ)
+New Zealand,lost,12 runs,0,won,2nd,Pakistan,Singapore,8/20/2000,Stephen Fleming (NZ)
+Pakistan,lost,12 runs,0,lost,2nd,Sri Lanka,Fatullah,2/25/2014,
+Pakistan,lost,12 runs,0,lost,2nd,Sri Lanka,Visakhapatnam,3/27/1999,
+Pakistan,lost,12 runs,0,won,2nd,Sri Lanka,Dambulla,5/18/2003,
+Pakistan,won,12 runs,0,lost,1st,New Zealand,Singapore,8/20/2000,Stephen Fleming (NZ)
+Pakistan,won,12 runs,0,won,1st,Australia,Adelaide,12/15/1996,
+Pakistan,won,12 runs,0,won,1st,India,Rawalpindi,3/16/2004,
+Sri Lanka,lost,12 runs,0,lost,2nd,India,Singapore,4/3/1996,
+Sri Lanka,won,12 runs,0,lost,1st,Pakistan,Dambulla,5/18/2003,
+Sri Lanka,won,12 runs,0,won,1st,India,Dambulla,7/18/2004,
+Sri Lanka,won,12 runs,0,won,1st,Pakistan,Fatullah,2/25/2014,
+Sri Lanka,won,12 runs,0,won,1st,Pakistan,Visakhapatnam,3/27/1999,
+New Zealand,won,120 runs,0,won,1st,Sri Lanka,Dunedin,1/25/2015,Brendon McCullum (NZ)
+Sri Lanka,lost,120 runs,0,lost,2nd,New Zealand,Dunedin,1/25/2015,Brendon McCullum (NZ)
+England,won,121 runs,0,won,1st,Pakistan,Southampton,9/22/2010,
+India,lost,121 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),8/5/2001,
+Pakistan,lost,121 runs,0,lost,2nd,England,Southampton,9/22/2010,
+Sri Lanka,won,121 runs,0,won,1st,India,Colombo (RPS),8/5/2001,
+Australia,won,122 runs,0,lost,1st,New Zealand,Napier,3/5/2005,Stephen Fleming (NZ)
+England,lost,122 runs,0,won,2nd,South Africa,The Oval,5/22/1999,
+New Zealand,lost,122 runs,0,won,2nd,Australia,Napier,3/5/2005,Stephen Fleming (NZ)
+South Africa,won,122 runs,0,lost,1st,England,The Oval,5/22/1999,
+India,lost,123 runs,0,lost,2nd,Pakistan,Bangalore,4/4/1999,
+Pakistan,won,123 runs,0,won,1st,India,Bangalore,4/4/1999,
+India,lost,124 runs,0,won,2nd,West Indies,Kochi,10/8/2014,
+New Zealand,lost,124 runs,0,lost,2nd,Pakistan,Lahore,12/1/2003,
+Pakistan,lost,124 runs,0,lost,2nd,South Africa,Mohali,10/27/2006,
+Pakistan,won,124 runs,0,won,1st,New Zealand,Lahore,12/1/2003,
+South Africa,won,124 runs,0,won,1st,Pakistan,Mohali,10/27/2006,
+West Indies,won,124 runs,0,lost,1st,India,Kochi,10/8/2014,
+Australia,won,125 runs,0,lost,1st,India,Johannesburg,3/23/2003,
+Australia,won,125 runs,0,won,1st,England,Manchester,6/14/2001,
+Australia,won,125 runs,0,won,1st,West Indies,Melbourne,2/19/2010,
+England,lost,125 runs,0,lost,2nd,Australia,Manchester,6/14/2001,
+India,lost,125 runs,0,won,2nd,Australia,Johannesburg,3/23/2003,
+Pakistan,lost,125 runs,0,won,2nd,South Africa,Bloemfontein,3/10/2013,
+South Africa,won,125 runs,0,lost,1st,Pakistan,Bloemfontein,3/10/2013,
+West Indies,lost,125 runs,0,lost,2nd,Australia,Melbourne,2/19/2010,
+England,lost,126 runs,0,lost,2nd,India,Hyderabad (Deccan),10/14/2011,
+England,won,126 runs,0,lost,1st,South Africa,The Oval,8/29/2008,
+India,won,126 runs,0,won,1st,England,Hyderabad (Deccan),10/14/2011,
+Pakistan,won,126 runs,0,lost,1st,West Indies,Providence,7/14/2013,
+South Africa,lost,126 runs,0,won,2nd,England,The Oval,8/29/2008,
+West Indies,lost,126 runs,0,won,2nd,Pakistan,Providence,7/14/2013,
+Australia,won,127 runs,0,won,1st,West Indies,Kuala Lumpur,9/24/2006,
+England,lost,127 runs,0,lost,2nd,India,Kochi,1/15/2013,
+India,won,127 runs,0,won,1st,England,Kochi,1/15/2013,
+West Indies,lost,127 runs,0,lost,2nd,Australia,Kuala Lumpur,9/24/2006,
+Australia,won,128 runs,0,won,1st,Sri Lanka,Sydney,2/8/2008,
+England,won,128 runs,0,lost,1st,Sri Lanka,Perth,1/29/1999,
+South Africa,lost,128 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),7/31/2013,
+Sri Lanka,lost,128 runs,0,lost,2nd,Australia,Sydney,2/8/2008,
+Sri Lanka,lost,128 runs,0,won,2nd,England,Perth,1/29/1999,
+Sri Lanka,won,128 runs,0,won,1st,South Africa,Colombo (RPS),7/31/2013,
+Pakistan,lost,129 runs,0,won,2nd,Sri Lanka,Karachi,1/21/2009,
+Sri Lanka,won,129 runs,0,lost,1st,Pakistan,Karachi,1/21/2009,
+Australia,lost,13 runs,0,lost,2nd,Sri Lanka,Melbourne,2/29/2008,
+England,lost,13 runs,0,lost,2nd,New Zealand,The Oval,6/12/2015,Brendon McCullum (NZ)
+England,lost,13 runs,0,lost,2nd,Pakistan,Rawalpindi,12/19/2005,
+New Zealand,won,13 runs,0,lost,1st,Sri Lanka,Christchurch,2/11/2001,Stephen Fleming (NZ)
+New Zealand,won,13 runs,0,won,1st,England,The Oval,6/12/2015,Brendon McCullum (NZ)
+Pakistan,lost,13 runs,0,won,1st,South Africa,Faisalabad,10/7/2003,
+Pakistan,won,13 runs,0,won,1st,England,Rawalpindi,12/19/2005,
+South Africa,won,13 runs,0,lost,2nd,Pakistan,Faisalabad,10/7/2003,
+Sri Lanka,lost,13 runs,0,won,2nd,New Zealand,Christchurch,2/11/2001,Stephen Fleming (NZ)
+Sri Lanka,won,13 runs,0,won,1st,Australia,Melbourne,2/29/2008,
+England,won,130 runs,0,won,1st,Pakistan,Abu Dhabi,2/13/2012,
+India,won,130 runs,0,won,1st,South Africa,Melbourne,2/22/2015,
+Pakistan,lost,130 runs,0,lost,2nd,England,Abu Dhabi,2/13/2012,
+Pakistan,won,130 runs,0,won,1st,West Indies,Sharjah,10/14/1999,
+South Africa,lost,130 runs,0,lost,2nd,India,Melbourne,2/22/2015,
+West Indies,lost,130 runs,0,lost,2nd,Pakistan,Sharjah,10/14/1999,
+Australia,won,131 runs,0,won,1st,New Zealand,Sydney,1/14/1998,Stephen Fleming (NZ)
+New Zealand,lost,131 runs,0,lost,2nd,Australia,Sydney,1/14/1998,Stephen Fleming (NZ)
+South Africa,won,131 runs,0,lost,1st,West Indies,Centurion,1/28/2015,
+West Indies,lost,131 runs,0,won,2nd,South Africa,Centurion,1/28/2015,
+Pakistan,lost,132 runs,0,won,2nd,South Africa,Durban,12/8/2002,
+Pakistan,won,132 runs,0,won,1st,Sri Lanka,Colombo (RPS),8/9/2009,
+South Africa,won,132 runs,0,lost,1st,Pakistan,Durban,12/8/2002,
+South Africa,won,132 runs,0,lost,1st,West Indies,St George's,5/5/2001,
+Sri Lanka,lost,132 runs,0,lost,2nd,Pakistan,Colombo (RPS),8/9/2009,
+West Indies,lost,132 runs,0,won,2nd,South Africa,St George's,5/5/2001,
+England,lost,133 runs,0,won,2nd,India,Cardiff,8/27/2014,
+India,won,133 runs,0,lost,1st,England,Cardiff,8/27/2014,
+Australia,won,134 runs,0,lost,1st,West Indies,Sydney,2/7/2001,
+India,lost,134 runs,0,won,2nd,Pakistan,Toronto,9/19/1998,
+India,lost,134 runs,0,won,2nd,South Africa,Durban,12/8/2013,
+Pakistan,won,134 runs,0,lost,1st,India,Toronto,9/19/1998,
+South Africa,won,134 runs,0,lost,1st,India,Durban,12/8/2013,
+West Indies,lost,134 runs,0,won,2nd,Australia,Sydney,2/7/2001,
+Australia,won,135 runs,0,won,1st,Pakistan,Perth,1/29/2010,
+India,lost,135 runs,0,lost,2nd,South Africa,Durban,1/12/2011,
+India,lost,135 runs,0,won,2nd,West Indies,Vijayawada,11/24/2002,
+Pakistan,lost,135 runs,0,lost,2nd,Australia,Perth,1/29/2010,
+Pakistan,won,135 runs,0,won,1st,Sri Lanka,Colombo (RPS),7/19/2015,
+South Africa,won,135 runs,0,won,1st,India,Durban,1/12/2011,
+Sri Lanka,lost,135 runs,0,lost,2nd,Pakistan,Colombo (RPS),7/19/2015,
+West Indies,won,135 runs,0,lost,1st,India,Vijayawada,11/24/2002,
+New Zealand,lost,138 runs,0,lost,2nd,Pakistan,Abu Dhabi,11/3/2009,Daniel Vettori (NZ)
+New Zealand,won,138 runs,0,lost,1st,Pakistan,Christchurch,2/25/2001,Stephen Fleming (NZ)
+Pakistan,lost,138 runs,0,won,2nd,New Zealand,Christchurch,2/25/2001,Stephen Fleming (NZ)
+Pakistan,won,138 runs,0,won,1st,New Zealand,Abu Dhabi,11/3/2009,Daniel Vettori (NZ)
+Pakistan,won,138 runs,0,won,1st,West Indies,Sharjah,10/19/1999,
+West Indies,lost,138 runs,0,lost,2nd,Pakistan,Sharjah,10/19/1999,
+India,lost,139 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),9/12/2009,
+Sri Lanka,won,139 runs,0,won,1st,India,Colombo (RPS),9/12/2009,
+Australia,lost,14 runs,0,won,2nd,West Indies,Brisbane,1/7/1996,
+Australia,won,14 runs,0,won,1st,South Africa,Sydney,1/27/1998,
+England,lost,14 runs,0,lost,2nd,South Africa,Birmingham,8/18/1998,
+England,lost,14 runs,0,lost,2nd,South Africa,East London,1/19/1996,
+England,won,14 runs,0,won,1st,New Zealand,Brisbane,2/6/2007,Stephen Fleming (NZ)
+India,won,14 runs,0,lost,1st,West Indies,Nagpur,1/21/2007,
+India,won,14 runs,0,won,1st,New Zealand,Gwalior,11/11/1999,Stephen Fleming (NZ)
+New Zealand,lost,14 runs,0,lost,2nd,England,Brisbane,2/6/2007,Stephen Fleming (NZ)
+New Zealand,lost,14 runs,0,lost,2nd,India,Gwalior,11/11/1999,Stephen Fleming (NZ)
+New Zealand,lost,14 runs,0,won,1st,Sri Lanka,Pallekele,11/4/2012,Ross Taylor (NZ)
+Pakistan,lost,14 runs,0,lost,2nd,South Africa,Lahore,10/29/2007,
+South Africa,lost,14 runs,0,lost,2nd,Australia,Sydney,1/27/1998,
+South Africa,won,14 runs,0,won,1st,England,Birmingham,8/18/1998,
+South Africa,won,14 runs,0,won,1st,England,East London,1/19/1996,
+South Africa,won,14 runs,0,won,1st,Pakistan,Lahore,10/29/2007,
+Sri Lanka,won,14 runs,0,lost,2nd,New Zealand,Pallekele,11/4/2012,Ross Taylor (NZ)
+West Indies,lost,14 runs,0,won,2nd,India,Nagpur,1/21/2007,
+West Indies,won,14 runs,0,lost,1st,Australia,Brisbane,1/7/1996,
+Australia,won,140 runs,0,lost,1st,Pakistan,Sydney,1/24/2010,
+India,won,140 runs,0,won,1st,Pakistan,Dhaka,6/10/2008,
+Pakistan,lost,140 runs,0,lost,2nd,India,Dhaka,6/10/2008,
+Pakistan,lost,140 runs,0,won,2nd,Australia,Sydney,1/24/2010,
+Australia,won,141 runs,0,won,1st,South Africa,Durban,4/3/2009,
+India,lost,141 runs,0,won,2nd,South Africa,Johannesburg,12/5/2013,
+Pakistan,won,141 runs,0,won,1st,South Africa,Durban,2/7/2007,
+South Africa,lost,141 runs,0,lost,2nd,Australia,Durban,4/3/2009,
+South Africa,lost,141 runs,0,lost,2nd,Pakistan,Durban,2/7/2007,
+South Africa,won,141 runs,0,lost,1st,India,Johannesburg,12/5/2013,
+Australia,won,142 runs,0,won,1st,Sri Lanka,Perth,12/22/2002,
+Sri Lanka,lost,142 runs,0,lost,2nd,Australia,Perth,12/22/2002,
+India,lost,143 runs,0,lost,2nd,Pakistan,Jaipur,3/24/1999,
+New Zealand,lost,143 runs,0,lost,2nd,South Africa,Auckland,3/27/1999,Stephen Fleming (NZ)
+New Zealand,won,143 runs,0,won,1st,West Indies,Wellington,3/21/2015,Brendon McCullum (NZ)
+Pakistan,lost,143 runs,0,lost,2nd,South Africa,Sharjah,4/13/1996,
+Pakistan,won,143 runs,0,won,1st,India,Jaipur,3/24/1999,
+South Africa,won,143 runs,0,won,1st,New Zealand,Auckland,3/27/1999,Stephen Fleming (NZ)
+South Africa,won,143 runs,0,won,1st,Pakistan,Sharjah,4/13/1996,
+West Indies,lost,143 runs,0,lost,2nd,New Zealand,Wellington,3/21/2015,Brendon McCullum (NZ)
+India,won,145 runs,0,won,1st,New Zealand,Hyderabad (Deccan),11/15/2003,
+New Zealand,lost,145 runs,0,lost,2nd,India,Hyderabad (Deccan),11/15/2003,
+Pakistan,won,146 runs,0,won,1st,Sri Lanka,Colombo (RPS),8/7/2009,
+Sri Lanka,lost,146 runs,0,lost,2nd,Pakistan,Colombo (RPS),8/7/2009,
+Australia,won,147 runs,0,lost,1st,New Zealand,Auckland,12/3/2005,Daniel Vettori (NZ)
+India,won,147 runs,0,won,1st,Sri Lanka,Colombo (RPS),2/3/2009,
+New Zealand,lost,147 runs,0,lost,2nd,Pakistan,Sharjah,12/14/2014,
+New Zealand,lost,147 runs,0,won,2nd,Australia,Auckland,12/3/2005,Daniel Vettori (NZ)
+Pakistan,won,147 runs,0,won,1st,New Zealand,Sharjah,12/14/2014,
+Sri Lanka,lost,147 runs,0,lost,2nd,India,Colombo (RPS),2/3/2009,
+South Africa,won,148 runs,0,lost,1st,West Indies,Johannesburg,1/18/2015,
+West Indies,lost,148 runs,0,won,2nd,South Africa,Johannesburg,1/18/2015,
+Australia,lost,15 runs,0,won,2nd,England,Lord's,6/29/2012,
+Australia,won,15 runs,0,won,1st,Pakistan,Melbourne,1/23/2000,
+Australia,won,15 runs,0,won,1st,South Africa,Durban,4/5/1997,
+Australia,won,15 runs,0,won,1st,Sri Lanka,Brisbane,3/4/2012,
+England,lost,15 runs,0,won,2nd,West Indies,North Sound,2/28/2014,
+England,won,15 runs,0,lost,1st,Australia,Lord's,6/29/2012,
+India,lost,15 runs,0,won,2nd,New Zealand,Hamilton,1/22/2014,Brendon McCullum (NZ)
+India,won,15 runs,0,won,1st,New Zealand,Sharjah,4/17/1998,Stephen Fleming (NZ)
+India,won,15 runs,0,won,1st,Sri Lanka,Colombo (RPS),1/31/2009,
+New Zealand,lost,15 runs,0,lost,2nd,India,Sharjah,4/17/1998,Stephen Fleming (NZ)
+New Zealand,won,15 runs,0,lost,1st,India,Hamilton,1/22/2014,Brendon McCullum (NZ)
+Pakistan,lost,15 runs,0,lost,2nd,Australia,Melbourne,1/23/2000,
+Pakistan,lost,15 runs,0,won,2nd,Sri Lanka,Colombo (RPS),7/14/1997,
+Pakistan,won,15 runs,0,won,1st,West Indies,Toronto,9/16/1999,
+South Africa,lost,15 runs,0,lost,2nd,Australia,Durban,4/5/1997,
+Sri Lanka,lost,15 runs,0,lost,2nd,Australia,Brisbane,3/4/2012,
+Sri Lanka,lost,15 runs,0,lost,2nd,India,Colombo (RPS),1/31/2009,
+Sri Lanka,won,15 runs,0,lost,1st,Pakistan,Colombo (RPS),7/14/1997,
+West Indies,lost,15 runs,0,lost,2nd,Pakistan,Toronto,9/16/1999,
+West Indies,won,15 runs,0,lost,1st,England,North Sound,2/28/2014,
+Pakistan,lost,150 runs,0,won,2nd,West Indies,Christchurch,2/21/2015,
+West Indies,won,150 runs,0,lost,1st,Pakistan,Christchurch,2/21/2015,
+Australia,won,152 runs,0,won,1st,India,Adelaide,1/26/2000,
+Australia,won,152 runs,0,won,1st,Pakistan,Sydney,2/4/2000,
+India,lost,152 runs,0,lost,2nd,Australia,Adelaide,1/26/2000,
+India,won,152 runs,0,won,1st,Sri Lanka,Nagpur,10/25/2005,
+Pakistan,lost,152 runs,0,lost,2nd,Australia,Sydney,2/4/2000,
+Sri Lanka,lost,152 runs,0,lost,2nd,India,Nagpur,10/25/2005,
+India,won,153 runs,0,won,1st,South Africa,Dhaka,4/13/2003,
+India,won,153 runs,0,won,1st,South Africa,Gwalior,2/24/2010,
+India,won,153 runs,0,won,1st,Sri Lanka,Kolkata,11/13/2014,
+India,won,153 runs,0,won,1st,West Indies,Indore,12/8/2011,
+New Zealand,lost,153 runs,0,lost,2nd,Pakistan,Karachi,4/21/2002,Stephen Fleming (NZ)
+Pakistan,won,153 runs,0,won,1st,New Zealand,Karachi,4/21/2002,
+South Africa,lost,153 runs,0,lost,2nd,India,Dhaka,4/13/2003,
+South Africa,lost,153 runs,0,lost,2nd,India,Gwalior,2/24/2010,
+Sri Lanka,lost,153 runs,0,lost,2nd,India,Kolkata,11/13/2014,
+West Indies,lost,153 runs,0,lost,2nd,India,Indore,12/8/2011,
+England,lost,155 runs,0,won,2nd,New Zealand,Wellington,2/16/2002,Stephen Fleming (NZ)
+New Zealand,won,155 runs,0,lost,1st,England,Wellington,2/16/2002,Stephen Fleming (NZ)
+England,lost,157 runs,0,won,2nd,Sri Lanka,Chester-le-Street,5/25/2014,
+India,lost,157 runs,0,lost,2nd,South Africa,Durban,11/22/2006,
+India,won,157 runs,0,lost,1st,Sri Lanka,Taunton,5/26/1999,
+South Africa,won,157 runs,0,won,1st,India,Durban,11/22/2006,
+Sri Lanka,lost,157 runs,0,won,2nd,India,Taunton,5/26/1999,
+Sri Lanka,won,157 runs,0,lost,1st,England,Chester-le-Street,5/25/2014,
+England,lost,158 runs,0,won,2nd,India,Rajkot,11/14/2008,
+India,won,158 runs,0,lost,1st,England,Rajkot,11/14/2008,
+India,lost,159 runs,0,lost,2nd,Pakistan,Delhi,4/17/2005,
+New Zealand,won,159 runs,0,lost,1st,West Indies,Queenstown,1/1/2014,Brendon McCullum (NZ)
+Pakistan,won,159 runs,0,won,1st,India,Delhi,4/17/2005,
+West Indies,lost,159 runs,0,won,2nd,New Zealand,Queenstown,1/1/2014,Brendon McCullum (NZ)
+Australia,won,16 runs,0,lost,1st,Sri Lanka,Adelaide,3/8/2012,
+Australia,won,16 runs,0,won,1st,England,Adelaide,1/26/1999,
+Australia,won,16 runs,0,won,1st,India,Mumbai,2/27/1996,
+England,lost,16 runs,0,lost,2nd,Australia,Adelaide,1/26/1999,
+England,lost,16 runs,0,won,1st,India,Kanpur,11/20/2008,
+England,won,16 runs,0,lost,1st,India,Cuttack,1/22/2002,
+England,won,16 runs,0,lost,1st,West Indies,Bridgetown,3/29/1998,
+England,won,16 runs,0,won,1st,Sri Lanka,Manchester,7/9/2011,
+India,lost,16 runs,0,lost,2nd,Australia,Mumbai,2/27/1996,
+India,lost,16 runs,0,won,2nd,England,Cuttack,1/22/2002,
+India,lost,16 runs,0,won,2nd,West Indies,Ahmedabad,12/5/2011,
+India,lost,16 runs,0,won,2nd,West Indies,Harare,7/7/2001,
+India,won,16 runs,0,lost,2nd,England,Kanpur,11/20/2008,
+India,won,16 runs,0,won,1st,West Indies,Kuala Lumpur,9/20/2006,
+New Zealand,lost,16 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),7/18/2001,Stephen Fleming (NZ)
+Pakistan,lost,16 runs,0,lost,2nd,Sri Lanka,Dambulla,6/15/2010,
+Pakistan,won,16 runs,0,won,1st,South Africa,Sharjah,3/31/2000,
+Pakistan,won,16 runs,0,won,1st,Sri Lanka,Sharjah,4/8/2001,
+South Africa,lost,16 runs,0,lost,2nd,Pakistan,Sharjah,3/31/2000,
+South Africa,won,16 runs,0,won,1st,West Indies,Port Elizabeth,1/28/2004,
+Sri Lanka,lost,16 runs,0,lost,2nd,England,Manchester,7/9/2011,
+Sri Lanka,lost,16 runs,0,lost,2nd,Pakistan,Sharjah,4/8/2001,
+Sri Lanka,lost,16 runs,0,won,2nd,Australia,Adelaide,3/8/2012,
+Sri Lanka,won,16 runs,0,lost,1st,West Indies,Perth,1/14/1996,
+Sri Lanka,won,16 runs,0,won,1st,New Zealand,Colombo (RPS),7/18/2001,Stephen Fleming (NZ)
+Sri Lanka,won,16 runs,0,won,1st,Pakistan,Dambulla,6/15/2010,
+West Indies,lost,16 runs,0,lost,2nd,India,Kuala Lumpur,9/20/2006,
+West Indies,lost,16 runs,0,lost,2nd,South Africa,Port Elizabeth,1/28/2004,
+West Indies,lost,16 runs,0,won,2nd,England,Bridgetown,3/29/1998,
+West Indies,lost,16 runs,0,won,2nd,Sri Lanka,Perth,1/14/1996,
+West Indies,won,16 runs,0,lost,1st,India,Ahmedabad,12/5/2011,
+West Indies,won,16 runs,0,lost,1st,India,Harare,7/7/2001,
+India,won,160 runs,0,lost,1st,West Indies,Vadodara,1/31/2007,
+West Indies,lost,160 runs,0,won,2nd,India,Vadodara,1/31/2007,
+India,lost,161 runs,0,won,2nd,Sri Lanka,Kingston,7/2/2013,
+Sri Lanka,won,161 runs,0,lost,1st,India,Kingston,7/2/2013,
+Australia,won,162 runs,0,won,1st,England,Melbourne,2/13/1999,
+England,lost,162 runs,0,lost,2nd,Australia,Melbourne,2/13/1999,
+Australia,won,164 runs,0,won,1st,New Zealand,Colombo (SSC),9/15/2002,Stephen Fleming (NZ)
+New Zealand,lost,164 runs,0,lost,2nd,Australia,Colombo (SSC),9/15/2002,Stephen Fleming (NZ)
+Pakistan,lost,164 runs,0,won,2nd,South Africa,Centurion,2/4/2007,
+South Africa,won,164 runs,0,lost,1st,Pakistan,Centurion,2/4/2007,
+England,lost,165 runs,0,won,2nd,Pakistan,Karachi,12/15/2005,
+Pakistan,lost,165 runs,0,lost,2nd,Sri Lanka,Hambantota,7/26/2015,
+Pakistan,won,165 runs,0,lost,1st,England,Karachi,12/15/2005,
+Sri Lanka,won,165 runs,0,won,1st,Pakistan,Hambantota,7/26/2015,
+Australia,won,167 runs,0,won,1st,Sri Lanka,Sydney,2/12/2006,
+Sri Lanka,lost,167 runs,0,lost,2nd,Australia,Sydney,2/12/2006,
+Australia,won,169 runs,0,won,1st,West Indies,Basseterre,7/6/2008,
+India,won,169 runs,0,lost,1st,Sri Lanka,Cuttack,11/2/2014,
+Sri Lanka,lost,169 runs,0,won,2nd,India,Cuttack,11/2/2014,
+West Indies,lost,169 runs,0,lost,2nd,Australia,Basseterre,7/6/2008,
+Australia,won,17 runs,0,lost,1st,West Indies,Melbourne,2/10/2013,
+Australia,won,17 runs,0,won,1st,New Zealand,Sydney,12/8/2004,Stephen Fleming (NZ)
+Australia,won,17 runs,0,won,1st,Pakistan,Amstelveen,8/28/2004,
+India,lost,17 runs,0,lost,2nd,South Africa,Durban,2/13/1997,
+New Zealand,lost,17 runs,0,lost,2nd,Australia,Sydney,12/8/2004,Stephen Fleming (NZ)
+Pakistan,lost,17 runs,0,lost,2nd,Australia,Amstelveen,8/28/2004,
+Pakistan,lost,17 runs,0,lost,2nd,West Indies,St George's,4/16/2000,
+Pakistan,won,17 runs,0,won,1st,West Indies,Bridgetown,4/19/2000,
+South Africa,lost,17 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),7/23/2013,
+South Africa,won,17 runs,0,won,1st,India,Durban,2/13/1997,
+South Africa,won,17 runs,0,won,1st,West Indies,North Sound,5/24/2010,
+Sri Lanka,won,17 runs,0,won,1st,South Africa,Colombo (RPS),7/23/2013,
+West Indies,lost,17 runs,0,lost,2nd,Pakistan,Bridgetown,4/19/2000,
+West Indies,lost,17 runs,0,lost,2nd,South Africa,North Sound,5/24/2010,
+West Indies,lost,17 runs,0,won,2nd,Australia,Melbourne,2/10/2013,
+West Indies,won,17 runs,0,won,1st,Pakistan,St George's,4/16/2000,
+India,won,174 runs,0,won,1st,New Zealand,Hyderabad (Deccan),11/8/1999,Stephen Fleming (NZ)
+New Zealand,lost,174 runs,0,lost,2nd,India,Hyderabad (Deccan),11/8/1999,Stephen Fleming (NZ)
+South Africa,won,177 runs,0,won,1st,Sri Lanka,Centurion,11/29/2002,
+Sri Lanka,lost,177 runs,0,lost,2nd,South Africa,Centurion,11/29/2002,
+Australia,won,18 runs,0,lost,1st,Sri Lanka,Melbourne,1/18/1996,
+Australia,won,18 runs,0,won,1st,India,Kuala Lumpur,9/22/2006,
+Australia,won,18 runs,0,won,1st,India,Melbourne,1/9/2004,
+Australia,won,18 runs,0,won,1st,India,Nagpur,10/14/2007,
+Australia,won,18 runs,0,won,1st,India,Sydney,2/24/2008,
+Australia,won,18 runs,0,won,1st,Pakistan,Melbourne,2/4/2005,
+England,won,18 runs,0,won,1st,West Indies,Chennai,3/17/2011,
+India,lost,18 runs,0,lost,2nd,Australia,Kuala Lumpur,9/22/2006,
+India,lost,18 runs,0,lost,2nd,Australia,Melbourne,1/9/2004,
+India,lost,18 runs,0,lost,2nd,Australia,Nagpur,10/14/2007,
+India,lost,18 runs,0,lost,2nd,Australia,Sydney,2/24/2008,
+India,lost,18 runs,0,lost,2nd,South Africa,Rajkot,10/18/2015,
+India,lost,18 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),8/9/2005,
+India,lost,18 runs,0,won,2nd,West Indies,Kingstown,4/30/1997,
+India,won,18 runs,0,lost,1st,Pakistan,Dhaka,1/11/1998,
+Pakistan,lost,18 runs,0,lost,2nd,Australia,Melbourne,2/4/2005,
+Pakistan,lost,18 runs,0,lost,2nd,South Africa,Colombo (RPS),7/8/2000,
+Pakistan,lost,18 runs,0,won,2nd,India,Dhaka,1/11/1998,
+South Africa,won,18 runs,0,won,1st,India,Rajkot,10/18/2015,
+South Africa,won,18 runs,0,won,1st,Pakistan,Colombo (RPS),7/8/2000,
+Sri Lanka,lost,18 runs,0,won,2nd,Australia,Melbourne,1/18/1996,
+Sri Lanka,won,18 runs,0,won,1st,India,Colombo (RPS),8/9/2005,
+West Indies,lost,18 runs,0,lost,2nd,England,Chennai,3/17/2011,
+West Indies,won,18 runs,0,lost,1st,India,Kingstown,4/30/1997,
+South Africa,lost,180 runs,0,won,2nd,Sri Lanka,Colombo (RPS),7/20/2013,
+Sri Lanka,won,180 runs,0,lost,1st,South Africa,Colombo (RPS),7/20/2013,
+Pakistan,won,182 runs,0,won,1st,South Africa,Port Elizabeth,12/11/2002,
+South Africa,lost,182 runs,0,lost,2nd,Pakistan,Port Elizabeth,12/11/2002,
+India,won,183 runs,0,lost,1st,Sri Lanka,Johannesburg,3/10/2003,
+Sri Lanka,lost,183 runs,0,won,2nd,India,Johannesburg,3/10/2003,
+New Zealand,lost,189 runs,0,lost,2nd,Sri Lanka,Auckland,1/6/2007,Stephen Fleming (NZ)
+Sri Lanka,won,189 runs,0,won,1st,New Zealand,Auckland,1/6/2007,Stephen Fleming (NZ)
+Australia,lost,19 runs,0,lost,2nd,India,Brisbane,1/18/2004,
+Australia,won,19 runs,0,won,1st,South Africa,Johannesburg,3/22/2002,
+England,lost,19 runs,0,won,2nd,India,Bangalore,11/23/2008,
+England,won,19 runs,0,won,1st,Sri Lanka,Adelaide,1/17/2003,
+India,lost,19 runs,0,won,2nd,West Indies,Port of Spain,5/28/2006,
+India,won,19 runs,0,lost,1st,England,Bangalore,11/23/2008,
+India,won,19 runs,0,won,1st,Australia,Brisbane,1/18/2004,
+New Zealand,lost,19 runs,0,lost,2nd,South Africa,Cape Town,10/28/2005,Stephen Fleming (NZ)
+Pakistan,lost,19 runs,0,won,2nd,Sri Lanka,Sharjah,4/4/1997,
+South Africa,lost,19 runs,0,lost,2nd,Australia,Johannesburg,3/22/2002,
+South Africa,lost,19 runs,0,lost,2nd,West Indies,Karachi,3/11/1996,
+South Africa,won,19 runs,0,won,1st,New Zealand,Cape Town,10/28/2005,Stephen Fleming (NZ)
+Sri Lanka,lost,19 runs,0,lost,2nd,England,Adelaide,1/17/2003,
+Sri Lanka,won,19 runs,0,lost,1st,Pakistan,Sharjah,4/4/1997,
+Sri Lanka,won,19 runs,0,won,2nd,West Indies,Pallekele,11/7/2015,
+West Indies,lost,19 runs,0,lost,1st,Sri Lanka,Pallekele,11/7/2015,
+West Indies,won,19 runs,0,lost,1st,India,Port of Spain,5/28/2006,
+West Indies,won,19 runs,0,won,1st,South Africa,Karachi,3/11/1996,
+Australia,lost,196 runs,0,lost,2nd,South Africa,Cape Town,3/3/2006,
+South Africa,won,196 runs,0,won,1st,Australia,Cape Town,3/3/2006,
+Australia,won,2 runs,0,lost,1st,West Indies,Kingston,5/17/2003,
+Australia,won,2 runs,0,won,1st,New Zealand,Wellington,12/7/2005,Daniel Vettori (NZ)
+England,lost,2 runs,0,won,2nd,Pakistan,Lord's,6/12/2001,
+England,lost,2 runs,0,won,2nd,Sri Lanka,North Sound,4/4/2007,
+England,won,2 runs,0,lost,1st,India,Delhi,1/31/2002,
+India,lost,2 runs,0,won,2nd,England,Delhi,1/31/2002,
+India,lost,2 runs,0,won,2nd,Sri Lanka,Colombo (RPS),8/17/1997,
+New Zealand,lost,2 runs,0,lost,2nd,Australia,Wellington,12/7/2005,Daniel Vettori (NZ)
+New Zealand,lost,2 runs,0,lost,2nd,South Africa,Brisbane,1/9/1998,Stephen Fleming (NZ)
+New Zealand,won,2 runs,0,lost,1st,South Africa,Auckland,2/29/2004,Stephen Fleming (NZ)
+Pakistan,lost,2 runs,0,won,2nd,South Africa,Dubai (DSC),11/2/2010,
+Pakistan,won,2 runs,0,lost,1st,England,Lord's,6/12/2001,
+South Africa,lost,2 runs,0,won,2nd,New Zealand,Auckland,2/29/2004,Stephen Fleming (NZ)
+South Africa,won,2 runs,0,lost,1st,Pakistan,Dubai (DSC),11/2/2010,
+South Africa,won,2 runs,0,won,1st,New Zealand,Brisbane,1/9/1998,Stephen Fleming (NZ)
+Sri Lanka,won,2 runs,0,lost,1st,England,North Sound,4/4/2007,
+Sri Lanka,won,2 runs,0,lost,1st,India,Colombo (RPS),8/17/1997,
+West Indies,lost,2 runs,0,won,2nd,Australia,Kingston,5/17/2003,
+Australia,lost,2 wickets,0,won,1st,New Zealand,Perth,2/1/2009,Daniel Vettori (NZ)
+Australia,won,2 wickets,0,won,2nd,Pakistan,Centurion,9/30/2009,
+India,lost,2 wickets,0,won,1st,Pakistan,Brisbane,1/10/2000,
+New Zealand,lost,2 wickets,0,lost,1st,South Africa,Durban,11/25/2007,Daniel Vettori (NZ)
+New Zealand,lost,2 wickets,0,lost,1st,South Africa,Napier,3/26/1999,Stephen Fleming (NZ)
+New Zealand,won,2 wickets,0,lost,2nd,Australia,Perth,2/1/2009,Daniel Vettori (NZ)
+Pakistan,lost,2 wickets,0,lost,1st,Australia,Centurion,9/30/2009,
+Pakistan,won,2 wickets,0,lost,2nd,India,Brisbane,1/10/2000,
+South Africa,won,2 wickets,0,won,2nd,New Zealand,Durban,11/25/2007,Daniel Vettori (NZ)
+South Africa,won,2 wickets,0,won,2nd,New Zealand,Napier,3/26/1999,Stephen Fleming (NZ)
+South Africa,won,2 wickets,0,won,2nd,West Indies,Colombo (SSC),9/13/2002,
+South Africa,won,2 wickets,0,won,2nd,West Indies,Johannesburg,1/22/1999,
+West Indies,lost,2 wickets,0,lost,1st,South Africa,Colombo (SSC),9/13/2002,
+West Indies,lost,2 wickets,0,lost,1st,South Africa,Johannesburg,1/22/1999,
+Australia,won,2 wickets,1,lost,2nd,India,Sydney,1/22/2004,
+Australia,won,2 wickets,1,won,2nd,New Zealand,Pune,11/3/2003,Stephen Fleming (NZ)
+India,lost,2 wickets,1,lost,1st,Pakistan,Toronto,9/17/1996,
+India,lost,2 wickets,1,won,1st,Australia,Sydney,1/22/2004,
+India,won,2 wickets,1,won,2nd,New Zealand,Napier,1/12/1999,Dion  Nash (NZ)
+New Zealand,lost,2 wickets,1,lost,1st,Australia,Pune,11/3/2003,Stephen Fleming (NZ)
+New Zealand,lost,2 wickets,1,lost,1st,India,Napier,1/12/1999,Dion  Nash (NZ)
+Pakistan,won,2 wickets,1,won,2nd,India,Toronto,9/17/1996,
+South Africa,lost,2 wickets,1,lost,1st,Sri Lanka,Johannesburg,1/22/2012,
+Sri Lanka,won,2 wickets,1,won,2nd,South Africa,Johannesburg,1/22/2012,
+Australia,won,2 wickets,2,lost,2nd,England,Port Elizabeth,3/2/2003,
+England,lost,2 wickets,2,lost,1st,South Africa,East London,2/4/2000,
+England,lost,2 wickets,2,won,1st,Australia,Port Elizabeth,3/2/2003,
+England,lost,2 wickets,2,won,1st,India,The Oval,9/5/2007,
+England,lost,2 wickets,2,won,1st,Pakistan,Nottingham,9/1/1996,
+India,won,2 wickets,2,lost,2nd,England,The Oval,9/5/2007,
+Pakistan,lost,2 wickets,2,lost,1st,Sri Lanka,Dubai (DSC),12/20/2013,
+Pakistan,lost,2 wickets,2,won,1st,Sri Lanka,Abu Dhabi,12/27/2013,
+Pakistan,lost,2 wickets,2,won,1st,Sri Lanka,Colombo (RPS),6/18/2012,
+Pakistan,won,2 wickets,2,lost,2nd,England,Nottingham,9/1/1996,
+South Africa,won,2 wickets,2,won,2nd,England,East London,2/4/2000,
+Sri Lanka,won,2 wickets,2,lost,2nd,Pakistan,Abu Dhabi,12/27/2013,
+Sri Lanka,won,2 wickets,2,lost,2nd,Pakistan,Colombo (RPS),6/18/2012,
+Sri Lanka,won,2 wickets,2,won,2nd,Pakistan,Dubai (DSC),12/20/2013,
+Australia,won,2 wickets,3,lost,2nd,New Zealand,Melbourne,1/29/2002,Stephen Fleming (NZ)
+England,lost,2 wickets,3,won,1st,India,Lord's,7/13/2002,
+England,won,2 wickets,3,won,2nd,West Indies,Georgetown,4/18/2004,
+India,lost,2 wickets,3,lost,1st,West Indies,Visakhapatnam,11/24/2013,
+India,won,2 wickets,3,lost,2nd,England,Lord's,7/13/2002,
+New Zealand,lost,2 wickets,3,won,1st,Australia,Melbourne,1/29/2002,Stephen Fleming (NZ)
+New Zealand,lost,2 wickets,3,won,1st,South Africa,Bloemfontein,10/23/2005,Stephen Fleming (NZ)
+South Africa,won,2 wickets,3,lost,2nd,New Zealand,Bloemfontein,10/23/2005,Stephen Fleming (NZ)
+West Indies,lost,2 wickets,3,lost,1st,England,Georgetown,4/18/2004,
+West Indies,won,2 wickets,3,won,2nd,India,Visakhapatnam,11/24/2013,
+Australia,lost,2 wickets,4,won,1st,New Zealand,Napier,3/3/2010,Ross Taylor (NZ)
+Australia,won,2 wickets,4,lost,2nd,England,Sydney,2/2/2011,
+Australia,won,2 wickets,4,lost,2nd,Pakistan,Perth,1/31/2010,
+England,lost,2 wickets,4,won,1st,Australia,Sydney,2/2/2011,
+England,lost,2 wickets,4,won,1st,Pakistan,Manchester,6/17/2003,
+India,lost,2 wickets,4,lost,1st,Sri Lanka,Fatullah,2/28/2014,
+New Zealand,won,2 wickets,4,lost,2nd,Australia,Napier,3/3/2010,Ross Taylor (NZ)
+Pakistan,lost,2 wickets,4,won,1st,Australia,Perth,1/31/2010,
+Pakistan,won,2 wickets,4,lost,2nd,England,Manchester,6/17/2003,
+Sri Lanka,won,2 wickets,4,won,2nd,India,Fatullah,2/28/2014,
+Australia,won,2 wickets,5,lost,2nd,South Africa,Sydney,11/23/2014,
+India,won,2 wickets,5,lost,2nd,Sri Lanka,Adelaide,2/19/2008,
+South Africa,lost,2 wickets,5,won,1st,Australia,Sydney,11/23/2014,
+Sri Lanka,lost,2 wickets,5,won,1st,India,Adelaide,2/19/2008,
+Australia,lost,2 wickets,6,lost,1st,New Zealand,Christchurch,12/10/2005,Daniel Vettori (NZ)
+India,lost,2 wickets,6,lost,1st,South Africa,Faridabad,3/15/2000,
+New Zealand,lost,2 wickets,6,won,1st,Pakistan,Napier,2/1/2011,Daniel Vettori (NZ)
+New Zealand,won,2 wickets,6,won,2nd,Australia,Christchurch,12/10/2005,Daniel Vettori (NZ)
+Pakistan,won,2 wickets,6,lost,2nd,New Zealand,Napier,2/1/2011,Daniel Vettori (NZ)
+South Africa,won,2 wickets,6,won,2nd,India,Faridabad,3/15/2000,
+Australia,lost,2 wickets,7,won,1st,India,Bangalore,10/21/1996,
+Australia,lost,2 wickets,7,won,1st,Pakistan,Melbourne (Docklands),6/15/2002,
+England,lost,2 wickets,7,lost,1st,Pakistan,Southampton,9/5/2006,
+England,lost,2 wickets,7,lost,1st,West Indies,The Oval,9/25/2004,
+England,won,2 wickets,7,lost,2nd,Sri Lanka,Dambulla,10/7/2007,
+India,won,2 wickets,7,lost,2nd,Australia,Bangalore,10/21/1996,
+Pakistan,won,2 wickets,7,lost,2nd,Australia,Melbourne (Docklands),6/15/2002,
+Pakistan,won,2 wickets,7,won,2nd,England,Southampton,9/5/2006,
+Sri Lanka,lost,2 wickets,7,won,1st,England,Dambulla,10/7/2007,
+West Indies,won,2 wickets,7,won,2nd,England,The Oval,9/25/2004,
+Australia,won,2 wickets,8,lost,2nd,New Zealand,Sydney,1/21/2007,Stephen Fleming (NZ)
+New Zealand,lost,2 wickets,8,won,1st,Australia,Sydney,1/21/2007,Stephen Fleming (NZ)
+India,won,2 wickets,10,lost,2nd,South Africa,Cape Town,1/18/2011,
+Pakistan,won,2 wickets,10,won,2nd,West Indies,Faisalabad,12/7/2006,
+South Africa,lost,2 wickets,10,won,1st,India,Cape Town,1/18/2011,
+West Indies,lost,2 wickets,10,lost,1st,Pakistan,Faisalabad,12/7/2006,
+Pakistan,lost,2 wickets,11,won,1st,Sri Lanka,Pallekele,7/15/2015,
+Sri Lanka,won,2 wickets,11,lost,2nd,Pakistan,Pallekele,7/15/2015,
+Australia,lost,2 wickets,16,won,1st,South Africa,Faridabad,10/25/1996,
+South Africa,won,2 wickets,16,lost,2nd,Australia,Faridabad,10/25/1996,
+Australia,lost,2 wickets,24,won,1st,India,Mumbai,10/17/2007,
+India,won,2 wickets,24,lost,2nd,Australia,Mumbai,10/17/2007,
+India,won,2 wickets,40,lost,2nd,New Zealand,Wellington,1/8/2003,Stephen Fleming (NZ)
+New Zealand,lost,2 wickets,40,won,1st,India,Wellington,1/8/2003,Stephen Fleming (NZ)
+Pakistan,lost,2 wickets,56,lost,1st,West Indies,The Oval,6/7/2013,
+South Africa,lost,2 wickets,56,won,1st,Sri Lanka,Nairobi (Club),10/1/1996,
+Sri Lanka,won,2 wickets,56,lost,2nd,South Africa,Nairobi (Club),10/1/1996,
+West Indies,won,2 wickets,56,won,2nd,Pakistan,The Oval,6/7/2013,
+New Zealand,lost,2 wickets,135,lost,1st,West Indies,Auckland,12/26/2013,Brendon McCullum (NZ)
+West Indies,won,2 wickets,135,won,2nd,New Zealand,Auckland,12/26/2013,Brendon McCullum (NZ)
+Australia,lost,20 runs,0,won,2nd,India,Nairobi (Gym),10/7/2000,
+Australia,lost,20 runs,0,won,2nd,Sri Lanka,The Oval,6/17/2013,
+Australia,won,20 runs,0,won,1st,West Indies,Port of Spain,4/18/1999,
+England,lost,20 runs,0,lost,2nd,India,Sharjah,4/9/1999,
+England,lost,20 runs,0,won,2nd,Sri Lanka,Lord's,6/17/2006,
+England,won,20 runs,0,won,1st,Pakistan,Abu Dhabi,2/15/2012,
+England,won,20 runs,0,won,1st,South Africa,Leeds,8/22/2008,
+India,won,20 runs,0,lost,1st,Australia,Nairobi (Gym),10/7/2000,
+India,won,20 runs,0,lost,1st,Pakistan,Toronto,9/13/1997,
+India,won,20 runs,0,won,1st,England,Sharjah,4/9/1999,
+India,won,20 runs,0,won,1st,Sri Lanka,Pallekele,8/4/2012,
+India,won,20 runs,0,won,1st,West Indies,Cuttack,1/24/2007,
+India,won,20 runs,0,won,1st,West Indies,Kingston,6/26/2009,
+New Zealand,lost,20 runs,0,lost,2nd,Sri Lanka,Napier,1/8/2006,Stephen Fleming (NZ)
+New Zealand,lost,20 runs,0,lost,2nd,West Indies,Basseterre,7/16/2012,Ross Taylor (NZ)
+New Zealand,lost,20 runs,0,won,2nd,South Africa,Centurion,8/19/2015,
+New Zealand,won,20 runs,0,lost,1st,West Indies,Port Elizabeth,2/13/2003,Stephen Fleming (NZ)
+New Zealand,won,20 runs,0,won,1st,West Indies,Christchurch,1/11/2000,Stephen Fleming (NZ)
+Pakistan,lost,20 runs,0,lost,2nd,England,Abu Dhabi,2/15/2012,
+Pakistan,lost,20 runs,0,won,2nd,India,Toronto,9/13/1997,
+South Africa,lost,20 runs,0,lost,2nd,England,Leeds,8/22/2008,
+South Africa,won,20 runs,0,lost,1st,New Zealand,Centurion,8/19/2015,
+Sri Lanka,lost,20 runs,0,lost,2nd,India,Pallekele,8/4/2012,
+Sri Lanka,won,20 runs,0,lost,1st,Australia,The Oval,6/17/2013,
+Sri Lanka,won,20 runs,0,lost,1st,England,Lord's,6/17/2006,
+Sri Lanka,won,20 runs,0,won,1st,New Zealand,Napier,1/8/2006,Stephen Fleming (NZ)
+West Indies,lost,20 runs,0,lost,2nd,Australia,Port of Spain,4/18/1999,
+West Indies,lost,20 runs,0,lost,2nd,India,Cuttack,1/24/2007,
+West Indies,lost,20 runs,0,lost,2nd,India,Kingston,6/26/2009,
+West Indies,lost,20 runs,0,lost,2nd,New Zealand,Christchurch,1/11/2000,Stephen Fleming (NZ)
+West Indies,lost,20 runs,0,won,2nd,New Zealand,Port Elizabeth,2/13/2003,Stephen Fleming (NZ)
+West Indies,won,20 runs,0,won,1st,New Zealand,Basseterre,7/16/2012,Ross Taylor (NZ)
+India,lost,200 runs,0,lost,2nd,New Zealand,Dambulla,8/10/2010,Ross Taylor (NZ)
+New Zealand,won,200 runs,0,won,1st,India,Dambulla,8/10/2010,Ross Taylor (NZ)
+New Zealand,lost,203 runs,0,won,2nd,West Indies,Hamilton,1/8/2014,Brendon McCullum (NZ)
+West Indies,won,203 runs,0,lost,1st,New Zealand,Hamilton,1/8/2014,Brendon McCullum (NZ)
+Australia,won,208 runs,0,won,1st,India,Sydney,2/8/2004,
+India,lost,208 runs,0,lost,2nd,Australia,Sydney,2/8/2004,
+South Africa,won,209 runs,0,won,1st,West Indies,Cape Town,1/25/2004,
+West Indies,lost,209 runs,0,lost,2nd,South Africa,Cape Town,1/25/2004,
+Australia,lost,21 runs,0,lost,2nd,England,Adelaide,1/26/2011,
+England,lost,21 runs,0,lost,2nd,West Indies,Providence,3/22/2009,
+England,won,21 runs,0,won,1st,Australia,Adelaide,1/26/2011,
+India,won,21 runs,0,won,1st,Sri Lanka,Hambantota,7/21/2012,
+New Zealand,won,21 runs,0,won,1st,Sri Lanka,Wellington,1/6/2006,Stephen Fleming (NZ)
+New Zealand,won,21 runs,0,won,1st,West Indies,Christchurch,2/25/2006,Stephen Fleming (NZ)
+Pakistan,won,21 runs,0,won,1st,Sri Lanka,Dubai (DSC),11/18/2011,
+Sri Lanka,lost,21 runs,0,lost,2nd,India,Hambantota,7/21/2012,
+Sri Lanka,lost,21 runs,0,lost,2nd,New Zealand,Wellington,1/6/2006,Stephen Fleming (NZ)
+Sri Lanka,lost,21 runs,0,lost,2nd,Pakistan,Dubai (DSC),11/18/2011,
+West Indies,lost,21 runs,0,lost,2nd,New Zealand,Christchurch,2/25/2006,Stephen Fleming (NZ)
+West Indies,won,21 runs,0,won,1st,England,Providence,3/22/2009,
+England,won,210 runs,0,lost,1st,New Zealand,Birmingham,6/9/2015,Brendon McCullum (NZ)
+New Zealand,lost,210 runs,0,won,2nd,England,Birmingham,6/9/2015,Brendon McCullum (NZ)
+India,lost,214 runs,0,lost,2nd,South Africa,Mumbai,10/25/2015,
+South Africa,won,214 runs,0,won,1st,India,Mumbai,10/25/2015,
+Australia,won,215 runs,0,won,1st,New Zealand,St George's,4/20/2007,Stephen Fleming (NZ)
+New Zealand,lost,215 runs,0,lost,2nd,Australia,St George's,4/20/2007,Stephen Fleming (NZ)
+Pakistan,won,217 runs,0,won,1st,Sri Lanka,Sharjah,4/17/2002,
+Sri Lanka,lost,217 runs,0,lost,2nd,Pakistan,Sharjah,4/17/2002,
+Australia,lost,22 runs,0,lost,2nd,Sri Lanka,Adelaide,2/10/2006,
+England,lost,22 runs,0,lost,2nd,India,Kolkata,1/19/2002,
+England,lost,22 runs,0,won,2nd,New Zealand,Bristol,6/21/2008,Daniel Vettori (NZ)
+England,won,22 runs,0,won,1st,South Africa,Centurion,9/27/2009,
+India,won,22 runs,0,won,1st,England,Kolkata,1/19/2002,
+India,won,22 runs,0,won,1st,South Africa,Indore,10/14/2015,
+New Zealand,lost,22 runs,0,won,2nd,Pakistan,Dambulla,5/20/2003,Stephen Fleming (NZ)
+New Zealand,won,22 runs,0,lost,1st,England,Bristol,6/21/2008,Daniel Vettori (NZ)
+New Zealand,won,22 runs,0,lost,1st,Pakistan,Mohali,5/9/1997,Stephen Fleming (NZ)
+Pakistan,lost,22 runs,0,won,2nd,New Zealand,Mohali,5/9/1997,Stephen Fleming (NZ)
+Pakistan,won,22 runs,0,lost,1st,New Zealand,Dambulla,5/20/2003,Stephen Fleming (NZ)
+Pakistan,won,22 runs,0,lost,1st,West Indies,Gros Islet,5/22/2005,
+South Africa,lost,22 runs,0,lost,2nd,England,Centurion,9/27/2009,
+South Africa,lost,22 runs,0,lost,2nd,India,Indore,10/14/2015,
+Sri Lanka,won,22 runs,0,won,1st,Australia,Adelaide,2/10/2006,
+West Indies,lost,22 runs,0,won,2nd,Pakistan,Gros Islet,5/22/2005,
+Australia,won,224 runs,0,lost,1st,Pakistan,Nairobi (Gym),8/30/2002,
+Pakistan,lost,224 runs,0,won,2nd,Australia,Nairobi (Gym),8/30/2002,
+Australia,lost,23 runs,0,lost,2nd,New Zealand,Sydney,1/17/2002,
+Australia,lost,23 runs,0,won,2nd,New Zealand,Melbourne,1/11/2002,Stephen Fleming (NZ)
+England,lost,23 runs,0,lost,2nd,India,Lord's,9/5/2004,
+England,lost,23 runs,0,lost,2nd,Pakistan,The Oval,9/17/2010,
+England,lost,23 runs,0,lost,2nd,Sri Lanka,Manchester,7/7/2002,
+India,won,23 runs,0,lost,1st,Sri Lanka,Colombo (SSC),8/29/1999,
+India,won,23 runs,0,won,1st,England,Lord's,9/5/2004,
+New Zealand,won,23 runs,0,lost,1st,Australia,Melbourne,1/11/2002,Stephen Fleming (NZ)
+New Zealand,won,23 runs,0,won,1st,Australia,Sydney,1/17/2002,Stephen Fleming (NZ)
+Pakistan,won,23 runs,0,won,1st,England,The Oval,9/17/2010,
+Pakistan,won,23 runs,0,won,1st,South Africa,Cape Town,11/24/2013,
+South Africa,lost,23 runs,0,lost,2nd,Pakistan,Cape Town,11/24/2013,
+Sri Lanka,lost,23 runs,0,won,2nd,India,Colombo (SSC),8/29/1999,
+Sri Lanka,won,23 runs,0,won,1st,England,Manchester,7/7/2002,
+Pakistan,lost,234 runs,0,lost,2nd,Sri Lanka,Lahore,1/24/2009,
+Sri Lanka,won,234 runs,0,won,1st,Pakistan,Lahore,1/24/2009,
+Australia,won,24 runs,0,lost,1st,India,Mohali,11/2/2009,
+Australia,won,24 runs,0,lost,1st,South Africa,Port Elizabeth,3/5/2006,
+Australia,won,24 runs,0,lost,1st,Sri Lanka,Melbourne,2/22/2008,
+England,won,24 runs,0,lost,1st,Pakistan,Chester-le-Street,9/10/2010,
+India,lost,24 runs,0,won,2nd,Australia,Mohali,11/2/2009,
+India,lost,24 runs,0,won,2nd,New Zealand,Napier,1/19/2014,Brendon McCullum (NZ)
+New Zealand,lost,24 runs,0,lost,2nd,West Indies,Basseterre,7/14/2012,Ross Taylor (NZ)
+New Zealand,won,24 runs,0,lost,1st,India,Napier,1/19/2014,Brendon McCullum (NZ)
+Pakistan,lost,24 runs,0,won,2nd,England,Chester-le-Street,9/10/2010,
+Pakistan,won,24 runs,0,won,1st,West Indies,Abu Dhabi,11/14/2008,
+South Africa,lost,24 runs,0,won,2nd,Australia,Port Elizabeth,3/5/2006,
+Sri Lanka,lost,24 runs,0,won,2nd,Australia,Melbourne,2/22/2008,
+West Indies,lost,24 runs,0,lost,2nd,Pakistan,Abu Dhabi,11/14/2008,
+West Indies,won,24 runs,0,won,1st,New Zealand,Basseterre,7/14/2012,Ross Taylor (NZ)
+India,lost,245 runs,0,lost,2nd,Sri Lanka,Sharjah,10/29/2000,
+Sri Lanka,won,245 runs,0,won,1st,India,Sharjah,10/29/2000,
+Australia,lost,25 runs,0,lost,2nd,South Africa,Cape Town,4/9/2009,
+Australia,won,25 runs,0,lost,1st,West Indies,Gros Islet,5/21/2003,
+England,lost,25 runs,0,won,2nd,Sri Lanka,Colombo (RPS),11/26/2014,
+England,won,25 runs,0,lost,1st,West Indies,North Sound,3/5/2014,
+India,lost,25 runs,0,lost,2nd,Pakistan,Dhaka,6/14/2008,
+India,lost,25 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),8/1/2004,
+Pakistan,lost,25 runs,0,lost,2nd,Sri Lanka,Dubai (DSC),11/14/2011,
+Pakistan,won,25 runs,0,won,1st,India,Dhaka,6/14/2008,
+Pakistan,won,25 runs,0,won,1st,South Africa,Lahore,10/20/2007,
+South Africa,lost,25 runs,0,lost,2nd,Pakistan,Lahore,10/20/2007,
+South Africa,won,25 runs,0,won,1st,Australia,Cape Town,4/9/2009,
+Sri Lanka,won,25 runs,0,lost,1st,England,Colombo (RPS),11/26/2014,
+Sri Lanka,won,25 runs,0,won,1st,India,Colombo (RPS),8/1/2004,
+Sri Lanka,won,25 runs,0,won,1st,Pakistan,Dubai (DSC),11/14/2011,
+West Indies,lost,25 runs,0,won,2nd,Australia,Gros Islet,5/21/2003,
+West Indies,lost,25 runs,0,won,2nd,England,North Sound,3/5/2014,
+South Africa,won,257 runs,0,won,1st,West Indies,Sydney,2/27/2015,
+West Indies,lost,257 runs,0,lost,2nd,South Africa,Sydney,2/27/2015,
+South Africa,won,258 runs,0,won,1st,Sri Lanka,Paarl,1/11/2012,
+Sri Lanka,lost,258 runs,0,lost,2nd,South Africa,Paarl,1/11/2012,
+Australia,won,26 runs,0,won,1st,India,Sharjah,4/22/1998,
+England,won,26 runs,0,lost,1st,West Indies,Gros Islet,4/3/2009,
+England,won,26 runs,0,won,2nd,South Africa,Johannesburg,1/30/2005,
+India,lost,26 runs,0,lost,2nd,Australia,Sharjah,4/22/1998,
+India,lost,26 runs,0,won,2nd,South Africa,Nairobi (Gym),10/3/1999,
+India,won,26 runs,0,lost,1st,South Africa,Cardiff,6/6/2013,
+New Zealand,lost,26 runs,0,lost,2nd,South Africa,Hobart,1/15/2002,Stephen Fleming (NZ)
+Pakistan,won,26 runs,0,won,1st,Sri Lanka,Sharjah,11/20/2011,
+South Africa,lost,26 runs,0,lost,1st,England,Johannesburg,1/30/2005,
+South Africa,lost,26 runs,0,won,2nd,India,Cardiff,6/6/2013,
+South Africa,won,26 runs,0,lost,1st,India,Nairobi (Gym),10/3/1999,
+South Africa,won,26 runs,0,won,1st,New Zealand,Hobart,1/15/2002,Stephen Fleming (NZ)
+Sri Lanka,lost,26 runs,0,lost,2nd,Pakistan,Sharjah,11/20/2011,
+Sri Lanka,won,26 runs,0,lost,1st,West Indies,Colombo (SSC),2/6/2011,
+West Indies,lost,26 runs,0,won,2nd,England,Gros Islet,4/3/2009,
+West Indies,lost,26 runs,0,won,2nd,Sri Lanka,Colombo (SSC),2/6/2011,
+Australia,won,27 runs,0,won,1st,Pakistan,Abu Dhabi,4/27/2009,
+Australia,won,27 runs,0,won,1st,South Africa,Brisbane,1/20/2002,
+Australia,won,27 runs,0,won,1st,Sri Lanka,Colombo (RPS),8/26/1999,
+India,lost,27 runs,0,won,2nd,South Africa,Jaipur,10/23/1996,
+New Zealand,won,27 runs,0,lost,1st,South Africa,Kimberley,1/22/2013,Brendon McCullum (NZ)
+Pakistan,lost,27 runs,0,lost,2nd,Australia,Abu Dhabi,4/27/2009,
+Pakistan,won,27 runs,0,won,1st,West Indies,Bristol,5/16/1999,
+South Africa,lost,27 runs,0,lost,2nd,Australia,Brisbane,1/20/2002,
+South Africa,lost,27 runs,0,lost,2nd,Sri Lanka,Tangier,8/21/2002,
+South Africa,lost,27 runs,0,won,2nd,New Zealand,Kimberley,1/22/2013,Brendon McCullum (NZ)
+South Africa,won,27 runs,0,lost,1st,India,Jaipur,10/23/1996,
+Sri Lanka,lost,27 runs,0,lost,2nd,Australia,Colombo (RPS),8/26/1999,
+Sri Lanka,won,27 runs,0,won,1st,South Africa,Tangier,8/21/2002,
+West Indies,lost,27 runs,0,lost,2nd,Pakistan,Bristol,5/16/1999,
+Australia,won,28 runs,0,lost,1st,West Indies,Sydney,1/17/2001,
+Australia,won,28 runs,0,won,1st,India,Melbourne,1/12/2000,
+England,lost,28 runs,0,lost,2nd,New Zealand,Wellington,3/4/1997,Lee Germon (NZ)
+India,lost,28 runs,0,lost,2nd,Australia,Melbourne,1/12/2000,
+India,won,28 runs,0,won,1st,Pakistan,Sharjah,4/15/1996,
+New Zealand,lost,28 runs,0,won,2nd,Pakistan,Wellington,2/22/2001,Stephen Fleming (NZ)
+New Zealand,won,28 runs,0,won,1st,England,Wellington,3/4/1997,Lee Germon (NZ)
+Pakistan,lost,28 runs,0,lost,2nd,India,Sharjah,4/15/1996,
+Pakistan,lost,28 runs,0,lost,2nd,South Africa,Abu Dhabi,11/8/2013,
+Pakistan,won,28 runs,0,lost,1st,New Zealand,Wellington,2/22/2001,Stephen Fleming (NZ)
+Pakistan,won,28 runs,0,lost,1st,Sri Lanka,Tangier,8/14/2002,
+Pakistan,won,28 runs,0,won,1st,South Africa,Singapore,8/23/2000,
+Pakistan,won,28 runs,0,won,1st,Sri Lanka,Sharjah,4/13/2001,
+South Africa,lost,28 runs,0,lost,2nd,Pakistan,Singapore,8/23/2000,
+South Africa,won,28 runs,0,won,1st,Pakistan,Abu Dhabi,11/8/2013,
+Sri Lanka,lost,28 runs,0,lost,2nd,Pakistan,Sharjah,4/13/2001,
+Sri Lanka,lost,28 runs,0,won,2nd,Pakistan,Tangier,8/14/2002,
+West Indies,lost,28 runs,0,won,2nd,Australia,Sydney,1/17/2001,
+Australia,lost,29 runs,0,lost,2nd,Pakistan,Hobart,1/7/1997,
+Australia,lost,29 runs,0,lost,2nd,Sri Lanka,Sydney,11/5/2010,
+India,lost,29 runs,0,won,1st,West Indies,Kuala Lumpur,9/14/2006,
+India,won,29 runs,0,won,1st,Pakistan,Mohali,3/30/2011,
+New Zealand,won,29 runs,0,lost,1st,Sri Lanka,Sharjah,11/7/1996,Lee Germon (NZ)
+Pakistan,lost,29 runs,0,lost,2nd,India,Mohali,3/30/2011,
+Pakistan,lost,29 runs,0,won,2nd,Sri Lanka,Karachi,2/13/2000,
+Pakistan,won,29 runs,0,lost,1st,South Africa,Auckland,3/7/2015,
+Pakistan,won,29 runs,0,won,1st,Australia,Hobart,1/7/1997,
+South Africa,lost,29 runs,0,won,2nd,Pakistan,Auckland,3/7/2015,
+Sri Lanka,lost,29 runs,0,won,2nd,New Zealand,Sharjah,11/7/1996,Lee Germon (NZ)
+Sri Lanka,won,29 runs,0,lost,1st,Pakistan,Karachi,2/13/2000,
+Sri Lanka,won,29 runs,0,won,1st,Australia,Sydney,11/5/2010,
+West Indies,won,29 runs,0,lost,2nd,India,Kuala Lumpur,9/14/2006,
+Australia,won,3 runs,0,won,1st,India,Hyderabad (Deccan),11/5/2009,
+England,lost,3 runs,0,won,2nd,West Indies,Nottingham,7/20/2000,
+India,lost,3 runs,0,lost,2nd,Australia,Hyderabad (Deccan),11/5/2009,
+India,won,3 runs,0,lost,1st,Sri Lanka,Rajkot,12/15/2009,
+New Zealand,lost,3 runs,0,lost,1st,Sri Lanka,Hamilton,2/8/2001,Stephen Fleming (NZ)
+South Africa,lost,3 runs,0,lost,2nd,West Indies,Cape Town,2/9/2003,
+Sri Lanka,lost,3 runs,0,won,2nd,India,Rajkot,12/15/2009,
+Sri Lanka,won,3 runs,0,won,2nd,New Zealand,Hamilton,2/8/2001,Stephen Fleming (NZ)
+West Indies,won,3 runs,0,lost,1st,England,Nottingham,7/20/2000,
+West Indies,won,3 runs,0,won,1st,South Africa,Cape Town,2/9/2003,
+India,lost,3 wickets,0,won,1st,Pakistan,Ahmedabad,4/12/2005,
+New Zealand,lost,3 wickets,0,lost,1st,South Africa,Cape Town,11/4/2000,Stephen Fleming (NZ)
+Pakistan,won,3 wickets,0,lost,2nd,India,Ahmedabad,4/12/2005,
+South Africa,lost,3 wickets,0,lost,1st,West Indies,Kingston,4/28/2001,
+South Africa,won,3 wickets,0,won,2nd,New Zealand,Cape Town,11/4/2000,Stephen Fleming (NZ)
+West Indies,won,3 wickets,0,won,2nd,South Africa,Kingston,4/28/2001,
+Australia,won,3 wickets,1,won,2nd,England,Hobart,1/23/2015,
+England,lost,3 wickets,1,lost,1st,Australia,Hobart,1/23/2015,
+England,won,3 wickets,1,lost,2nd,New Zealand,Hobart,1/16/2007,Stephen Fleming (NZ)
+India,won,3 wickets,1,lost,2nd,Pakistan,Dambulla,6/19/2010,
+India,won,3 wickets,1,won,2nd,Pakistan,Dhaka,1/18/1998,
+New Zealand,lost,3 wickets,1,won,1st,England,Hobart,1/16/2007,Stephen Fleming (NZ)
+Pakistan,lost,3 wickets,1,lost,1st,India,Dhaka,1/18/1998,
+Pakistan,lost,3 wickets,1,won,1st,India,Dambulla,6/19/2010,
+Australia,lost,3 wickets,2,won,1st,Sri Lanka,Melbourne,1/16/1996,
+Australia,won,3 wickets,2,lost,2nd,New Zealand,Adelaide,12/7/1997,Stephen Fleming (NZ)
+India,lost,3 wickets,2,lost,1st,West Indies,Ahmedabad,10/26/2006,
+India,lost,3 wickets,2,won,1st,South Africa,Nagpur,3/12/2011,
+India,won,3 wickets,2,lost,2nd,South Africa,Kochi,3/9/2000,
+New Zealand,lost,3 wickets,2,won,1st,Australia,Adelaide,12/7/1997,Stephen Fleming (NZ)
+New Zealand,lost,3 wickets,2,won,1st,West Indies,Auckland,3/4/2006,Stephen Fleming (NZ)
+South Africa,lost,3 wickets,2,won,1st,India,Kochi,3/9/2000,
+South Africa,won,3 wickets,2,lost,2nd,India,Nagpur,3/12/2011,
+Sri Lanka,won,3 wickets,2,lost,2nd,Australia,Melbourne,1/16/1996,
+West Indies,won,3 wickets,2,lost,2nd,New Zealand,Auckland,3/4/2006,Stephen Fleming (NZ)
+West Indies,won,3 wickets,2,won,2nd,India,Ahmedabad,10/26/2006,
+Australia,lost,3 wickets,3,lost,1st,England,Cardiff,9/14/2013,
+Australia,lost,3 wickets,3,lost,1st,Sri Lanka,Hobart,1/21/1999,
+Australia,lost,3 wickets,3,won,1st,South Africa,Melbourne,1/16/2009,
+Australia,won,3 wickets,3,lost,2nd,Pakistan,Melbourne,1/16/1997,
+Australia,won,3 wickets,3,won,2nd,India,Colombo (SSC),9/6/1996,
+England,won,3 wickets,3,won,2nd,Australia,Cardiff,9/14/2013,
+India,lost,3 wickets,3,lost,1st,Australia,Colombo (SSC),9/6/1996,
+New Zealand,lost,3 wickets,3,lost,1st,Pakistan,Dubai (DSC),12/8/2014,
+New Zealand,lost,3 wickets,3,won,1st,Sri Lanka,Wellington,2/3/2001,Stephen Fleming (NZ)
+Pakistan,lost,3 wickets,3,won,1st,Australia,Melbourne,1/16/1997,
+Pakistan,won,3 wickets,3,won,2nd,New Zealand,Dubai (DSC),12/8/2014,
+South Africa,won,3 wickets,3,lost,2nd,Australia,Melbourne,1/16/2009,
+Sri Lanka,won,3 wickets,3,lost,2nd,New Zealand,Wellington,2/3/2001,Stephen Fleming (NZ)
+Sri Lanka,won,3 wickets,3,won,2nd,Australia,Hobart,1/21/1999,
+Australia,lost,3 wickets,4,won,1st,Sri Lanka,Hobart,2/24/2012,
+England,won,3 wickets,4,won,2nd,Sri Lanka,Leeds,7/2/2002,
+India,lost,3 wickets,4,lost,1st,Pakistan,Birmingham,9/19/2004,
+Pakistan,won,3 wickets,4,won,2nd,India,Birmingham,9/19/2004,
+Sri Lanka,lost,3 wickets,4,lost,1st,England,Leeds,7/2/2002,
+Sri Lanka,lost,3 wickets,4,won,1st,West Indies,Sharjah,10/13/1999,
+Sri Lanka,won,3 wickets,4,lost,2nd,Australia,Hobart,2/24/2012,
+West Indies,won,3 wickets,4,lost,2nd,Sri Lanka,Sharjah,10/13/1999,
+Australia,won,3 wickets,5,lost,2nd,South Africa,Port Elizabeth,4/6/2002,
+England,lost,3 wickets,5,won,1st,South Africa,Port Elizabeth,2/4/2005,
+India,lost,3 wickets,5,won,1st,Sri Lanka,Nagpur,12/18/2009,
+India,won,3 wickets,5,won,2nd,Sri Lanka,Sharjah,11/6/1998,
+New Zealand,won,3 wickets,5,lost,2nd,West Indies,Auckland,1/2/2000,Stephen Fleming (NZ)
+New Zealand,won,3 wickets,5,won,2nd,South Africa,Dunedin,2/14/1999,Dion  Nash (NZ)
+South Africa,lost,3 wickets,5,lost,1st,New Zealand,Dunedin,2/14/1999,Dion  Nash (NZ)
+South Africa,lost,3 wickets,5,won,1st,Australia,Port Elizabeth,4/6/2002,
+South Africa,won,3 wickets,5,lost,2nd,England,Port Elizabeth,2/4/2005,
+Sri Lanka,lost,3 wickets,5,lost,1st,India,Sharjah,11/6/1998,
+Sri Lanka,won,3 wickets,5,lost,2nd,India,Nagpur,12/18/2009,
+West Indies,lost,3 wickets,5,won,1st,New Zealand,Auckland,1/2/2000,Stephen Fleming (NZ)
+Australia,won,3 wickets,6,lost,2nd,South Africa,Melbourne,11/21/2014,
+England,lost,3 wickets,6,lost,1st,South Africa,Centurion,2/13/2005,
+England,lost,3 wickets,6,won,1st,New Zealand,Southampton,6/14/2015,Brendon McCullum (NZ)
+England,won,3 wickets,6,won,2nd,New Zealand,Chester-le-Street,6/20/2015,Brendon McCullum (NZ)
+New Zealand,lost,3 wickets,6,lost,1st,England,Chester-le-Street,6/20/2015,Brendon McCullum (NZ)
+New Zealand,won,3 wickets,6,lost,2nd,England,Southampton,6/14/2015,Brendon McCullum (NZ)
+Pakistan,lost,3 wickets,6,won,1st,South Africa,Nottingham,6/5/1999,
+South Africa,lost,3 wickets,6,won,1st,Australia,Melbourne,11/21/2014,
+South Africa,lost,3 wickets,6,won,1st,Sri Lanka,Colombo (RPS),8/20/2004,
+South Africa,won,3 wickets,6,lost,2nd,Pakistan,Nottingham,6/5/1999,
+South Africa,won,3 wickets,6,won,2nd,England,Centurion,2/13/2005,
+Sri Lanka,won,3 wickets,6,lost,2nd,South Africa,Colombo (RPS),8/20/2004,
+England,lost,3 wickets,7,lost,1st,New Zealand,Hamilton,2/17/2013,Brendon McCullum (NZ)
+England,won,3 wickets,7,won,2nd,India,The Oval,9/9/2011,
+India,lost,3 wickets,7,lost,1st,England,The Oval,9/9/2011,
+New Zealand,won,3 wickets,7,won,2nd,England,Hamilton,2/17/2013,Brendon McCullum (NZ)
+Australia,lost,3 wickets,8,won,1st,West Indies,St George's,5/30/2003,
+England,lost,3 wickets,8,lost,1st,South Africa,The Oval,5/21/1998,
+India,won,3 wickets,8,lost,2nd,Sri Lanka,Ranchi,11/16/2014,
+Pakistan,won,3 wickets,8,lost,2nd,South Africa,Durban,3/21/2013,
+South Africa,lost,3 wickets,8,won,1st,Pakistan,Durban,3/21/2013,
+South Africa,won,3 wickets,8,won,2nd,England,The Oval,5/21/1998,
+Sri Lanka,lost,3 wickets,8,won,1st,India,Ranchi,11/16/2014,
+West Indies,won,3 wickets,8,lost,2nd,Australia,St George's,5/30/2003,
+England,won,3 wickets,9,lost,2nd,West Indies,Ahmedabad,10/28/2006,
+West Indies,lost,3 wickets,9,won,1st,England,Ahmedabad,10/28/2006,
+Australia,lost,3 wickets,10,won,1st,England,Leeds,9/11/2015,
+England,won,3 wickets,10,lost,2nd,Australia,Leeds,9/11/2015,
+India,lost,3 wickets,10,won,1st,Sri Lanka,Dambulla,7/30/2005,
+Sri Lanka,won,3 wickets,10,lost,2nd,India,Dambulla,7/30/2005,
+England,lost,3 wickets,11,won,1st,South Africa,Johannesburg,1/13/1996,
+England,won,3 wickets,11,lost,2nd,West Indies,Sharjah,12/19/1997,
+South Africa,won,3 wickets,11,lost,2nd,England,Johannesburg,1/13/1996,
+West Indies,lost,3 wickets,11,won,1st,England,Sharjah,12/19/1997,
+England,won,3 wickets,12,lost,2nd,India,Manchester,8/30/2007,
+India,lost,3 wickets,12,won,1st,England,Manchester,8/30/2007,
+New Zealand,lost,3 wickets,12,won,1st,Pakistan,Lahore,11/29/2003,
+Pakistan,won,3 wickets,12,lost,2nd,New Zealand,Lahore,11/29/2003,
+Australia,lost,3 wickets,13,won,1st,Sri Lanka,Colombo (SSC),2/29/2004,
+Sri Lanka,won,3 wickets,13,lost,2nd,Australia,Colombo (SSC),2/29/2004,
+Australia,lost,3 wickets,15,won,1st,England,Bristol,6/19/2005,
+Australia,lost,3 wickets,15,won,1st,Sri Lanka,Melbourne,1/9/1996,
+Australia,won,3 wickets,15,lost,2nd,South Africa,Durban,10/28/2011,
+England,won,3 wickets,15,lost,2nd,Australia,Bristol,6/19/2005,
+South Africa,lost,3 wickets,15,won,1st,Australia,Durban,10/28/2011,
+Sri Lanka,won,3 wickets,15,lost,2nd,Australia,Melbourne,1/9/1996,
+Australia,lost,3 wickets,16,won,1st,Pakistan,Perth,1/30/2005,
+Australia,lost,3 wickets,16,won,1st,West Indies,Kuala Lumpur,9/18/2006,
+Pakistan,won,3 wickets,16,lost,2nd,Australia,Perth,1/30/2005,
+Pakistan,won,3 wickets,16,lost,2nd,Sri Lanka,Abu Dhabi,11/23/2011,
+Sri Lanka,lost,3 wickets,16,won,1st,Pakistan,Abu Dhabi,11/23/2011,
+West Indies,won,3 wickets,16,lost,2nd,Australia,Kuala Lumpur,9/18/2006,
+New Zealand,lost,3 wickets,17,won,1st,Pakistan,Rawalpindi,4/24/2002,Stephen Fleming (NZ)
+Pakistan,won,3 wickets,17,lost,2nd,New Zealand,Rawalpindi,4/24/2002,Stephen Fleming (NZ)
+Australia,won,3 wickets,18,won,2nd,Pakistan,Sharjah,9/3/2012,
+Pakistan,lost,3 wickets,18,lost,1st,Australia,Sharjah,9/3/2012,
+England,won,3 wickets,19,won,2nd,India,Perth,1/30/2015,
+India,lost,3 wickets,19,lost,1st,England,Perth,1/30/2015,
+Australia,lost,3 wickets,21,won,1st,South Africa,Sydney,1/23/2009,
+South Africa,won,3 wickets,21,lost,2nd,Australia,Sydney,1/23/2009,
+India,won,3 wickets,22,won,2nd,West Indies,Jodhpur,11/21/2002,
+India,won,3 wickets,22,won,2nd,West Indies,North Sound,6/11/2011,
+Pakistan,lost,3 wickets,22,lost,1st,South Africa,East London,4/11/1998,
+South Africa,won,3 wickets,22,won,2nd,Pakistan,East London,4/11/1998,
+West Indies,lost,3 wickets,22,lost,1st,India,Jodhpur,11/21/2002,
+West Indies,lost,3 wickets,22,lost,1st,India,North Sound,6/11/2011,
+Pakistan,won,3 wickets,29,won,2nd,West Indies,Bridgetown,4/28/2011,
+West Indies,lost,3 wickets,29,lost,1st,Pakistan,Bridgetown,4/28/2011,
+England,won,3 wickets,31,won,2nd,West Indies,North Sound,3/2/2014,
+West Indies,lost,3 wickets,31,lost,1st,England,North Sound,3/2/2014,
+Pakistan,lost,3 wickets,33,won,1st,South Africa,Sharjah,3/24/2000,
+South Africa,won,3 wickets,33,lost,2nd,Pakistan,Sharjah,3/24/2000,
+India,lost,3 wickets,38,lost,1st,West Indies,Chennai,1/27/2007,
+West Indies,won,3 wickets,38,won,2nd,India,Chennai,1/27/2007,
+New Zealand,won,3 wickets,42,lost,2nd,Sri Lanka,Christchurch,1/11/2015,Brendon McCullum (NZ)
+Sri Lanka,lost,3 wickets,42,won,1st,New Zealand,Christchurch,1/11/2015,Brendon McCullum (NZ)
+New Zealand,won,3 wickets,48,won,2nd,West Indies,Queenstown,2/22/2006,Stephen Fleming (NZ)
+West Indies,lost,3 wickets,48,lost,1st,New Zealand,Queenstown,2/22/2006,Stephen Fleming (NZ)
+New Zealand,lost,3 wickets,55,won,1st,Sri Lanka,Dambulla,8/13/2010,Ross Taylor (NZ)
+Sri Lanka,won,3 wickets,55,lost,2nd,New Zealand,Dambulla,8/13/2010,Ross Taylor (NZ)
+Australia,won,3 wickets,61,lost,2nd,England,Sydney,1/16/2015,
+England,lost,3 wickets,61,won,1st,Australia,Sydney,1/16/2015,
+India,won,3 wickets,62,won,2nd,Sri Lanka,Dambulla,8/20/2008,
+Sri Lanka,lost,3 wickets,62,lost,1st,India,Dambulla,8/20/2008,
+India,lost,3 wickets,74,lost,1st,New Zealand,Auckland,12/26/2002,Stephen Fleming (NZ)
+New Zealand,won,3 wickets,74,won,2nd,India,Auckland,12/26/2002,Stephen Fleming (NZ)
+England,won,3 wickets,114,won,2nd,Pakistan,Birmingham,9/10/2006,
+Pakistan,lost,3 wickets,114,lost,1st,England,Birmingham,9/10/2006,
+Australia,lost,3 wickets,134,won,1st,South Africa,Perth,11/16/2014,
+South Africa,won,3 wickets,134,lost,2nd,Australia,Perth,11/16/2014,
+Australia,lost,30 runs,0,won,2nd,New Zealand,Auckland,2/14/1998,Stephen Fleming (NZ)
+Australia,won,30 runs,0,lost,1st,West Indies,Gros Islet,3/25/2012,
+New Zealand,won,30 runs,0,lost,1st,Australia,Auckland,2/14/1998,Stephen Fleming (NZ)
+Pakistan,lost,30 runs,0,lost,2nd,West Indies,Dhaka,10/29/1998,
+Pakistan,won,30 runs,0,lost,1st,West Indies,Perth,2/1/2005,
+Pakistan,won,30 runs,0,won,1st,Sri Lanka,Gwalior,5/12/1997,
+South Africa,lost,30 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),7/14/2000,
+Sri Lanka,lost,30 runs,0,lost,2nd,Pakistan,Gwalior,5/12/1997,
+Sri Lanka,won,30 runs,0,won,1st,South Africa,Colombo (RPS),7/14/2000,
+West Indies,lost,30 runs,0,won,2nd,Australia,Gros Islet,3/25/2012,
+West Indies,lost,30 runs,0,won,2nd,Pakistan,Perth,2/1/2005,
+West Indies,won,30 runs,0,won,1st,Pakistan,Dhaka,10/29/1998,
+Australia,won,31 runs,0,won,1st,Pakistan,Sydney,2/6/2005,
+England,lost,31 runs,0,lost,2nd,Sri Lanka,Sydney,1/13/2003,
+India,lost,31 runs,0,won,2nd,Pakistan,Jaipur,11/18/2007,
+Pakistan,lost,31 runs,0,lost,2nd,Australia,Sydney,2/6/2005,
+Pakistan,won,31 runs,0,lost,1st,India,Jaipur,11/18/2007,
+Pakistan,won,31 runs,0,won,1st,West Indies,Abu Dhabi,11/16/2008,
+Sri Lanka,won,31 runs,0,won,1st,England,Sydney,1/13/2003,
+West Indies,lost,31 runs,0,lost,2nd,Pakistan,Abu Dhabi,11/16/2008,
+Australia,won,32 runs,0,lost,1st,New Zealand,Sydney,2/8/2009,Daniel Vettori (NZ)
+Australia,won,32 runs,0,lost,1st,South Africa,Perth,11/14/2014,
+Australia,won,32 runs,0,lost,1st,Sri Lanka,Hobart,1/23/2013,
+England,lost,32 runs,0,won,2nd,South Africa,Manchester,5/23/1998,
+India,lost,32 runs,0,won,2nd,Pakistan,Hobart,1/21/2000,
+New Zealand,lost,32 runs,0,won,2nd,Australia,Sydney,2/8/2009,Daniel Vettori (NZ)
+Pakistan,won,32 runs,0,lost,1st,India,Hobart,1/21/2000,
+South Africa,lost,32 runs,0,won,2nd,Australia,Perth,11/14/2014,
+South Africa,won,32 runs,0,lost,1st,England,Manchester,5/23/1998,
+Sri Lanka,lost,32 runs,0,won,2nd,Australia,Hobart,1/23/2013,
+Australia,won,33 runs,0,lost,1st,South Africa,Perth,2/3/2002,
+England,lost,33 runs,0,lost,2nd,Sri Lanka,Manchester,6/28/2006,
+England,won,33 runs,0,won,1st,New Zealand,Auckland,2/23/2002,Stephen Fleming (NZ)
+India,lost,33 runs,0,won,2nd,South Africa,Centurion,1/23/2011,
+India,won,33 runs,0,won,1st,Sri Lanka,Colombo (RPS),8/24/2008,
+New Zealand,lost,33 runs,0,lost,2nd,England,Auckland,2/23/2002,Stephen Fleming (NZ)
+South Africa,lost,33 runs,0,won,2nd,Australia,Perth,2/3/2002,
+South Africa,won,33 runs,0,lost,1st,India,Centurion,1/23/2011,
+Sri Lanka,lost,33 runs,0,lost,2nd,India,Colombo (RPS),8/24/2008,
+Sri Lanka,lost,33 runs,0,lost,2nd,West Indies,Colombo (RPS),8/6/2005,
+Sri Lanka,won,33 runs,0,won,1st,England,Manchester,6/28/2006,
+West Indies,won,33 runs,0,won,1st,Sri Lanka,Colombo (RPS),8/6/2005,
+Australia,lost,34 runs,0,lost,2nd,England,Sydney,2/11/2007,
+Australia,won,34 runs,0,lost,1st,New Zealand,Mohali,11/1/2006,Stephen Fleming (NZ)
+England,lost,34 runs,0,lost,1st,New Zealand,Christchurch,2/23/2008,Daniel Vettori (NZ)
+England,won,34 runs,0,lost,1st,New Zealand,Nottingham,6/5/2013,Brendon McCullum (NZ)
+England,won,34 runs,0,won,1st,Australia,Sydney,2/11/2007,
+India,won,34 runs,0,lost,1st,Pakistan,Toronto,9/18/1997,
+India,won,34 runs,0,won,1st,West Indies,Chennai,12/11/2011,
+New Zealand,lost,34 runs,0,lost,2nd,Sri Lanka,Wellington,1/29/2015,
+New Zealand,lost,34 runs,0,won,2nd,Australia,Mohali,11/1/2006,Stephen Fleming (NZ)
+New Zealand,lost,34 runs,0,won,2nd,England,Nottingham,6/5/2013,Brendon McCullum (NZ)
+New Zealand,won,34 runs,0,won,2nd,England,Christchurch,2/23/2008,Daniel Vettori (NZ)
+Pakistan,lost,34 runs,0,lost,2nd,South Africa,Cape Town,12/18/2002,
+Pakistan,lost,34 runs,0,won,2nd,India,Toronto,9/18/1997,
+Pakistan,lost,34 runs,0,won,2nd,South Africa,Johannesburg,3/17/2013,
+Pakistan,lost,34 runs,0,won,2nd,Sri Lanka,Gujranwala,2/16/2000,
+Pakistan,lost,34 runs,0,won,2nd,Sri Lanka,Singapore,4/2/1996,
+South Africa,won,34 runs,0,lost,1st,Pakistan,Johannesburg,3/17/2013,
+South Africa,won,34 runs,0,won,1st,Pakistan,Cape Town,12/18/2002,
+Sri Lanka,won,34 runs,0,lost,1st,Pakistan,Gujranwala,2/16/2000,
+Sri Lanka,won,34 runs,0,lost,1st,Pakistan,Singapore,4/2/1996,
+Sri Lanka,won,34 runs,0,won,1st,New Zealand,Wellington,1/29/2015,
+Sri Lanka,won,34 runs,0,won,1st,West Indies,Colombo (RPS),12/19/2001,
+West Indies,lost,34 runs,0,lost,2nd,India,Chennai,12/11/2011,
+West Indies,lost,34 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),12/19/2001,
+India,lost,35 runs,0,lost,2nd,Pakistan,Chennai,5/21/1997,
+India,lost,35 runs,0,won,2nd,New Zealand,Napier,12/29/2002,Stephen Fleming (NZ)
+India,won,35 runs,0,won,1st,South Africa,Chennai,10/22/2015,
+India,won,35 runs,0,won,1st,South Africa,Mumbai,11/6/1996,
+New Zealand,won,35 runs,0,lost,1st,India,Napier,12/29/2002,Stephen Fleming (NZ)
+Pakistan,won,35 runs,0,won,1st,India,Chennai,5/21/1997,
+South Africa,lost,35 runs,0,lost,2nd,India,Chennai,10/22/2015,
+South Africa,lost,35 runs,0,lost,2nd,India,Mumbai,11/6/1996,
+Sri Lanka,lost,35 runs,0,won,2nd,West Indies,Port of Spain,6/6/1997,
+Sri Lanka,won,35 runs,0,won,1st,West Indies,Port of Spain,4/13/1996,
+West Indies,lost,35 runs,0,lost,2nd,Sri Lanka,Port of Spain,4/13/1996,
+West Indies,won,35 runs,0,lost,1st,Sri Lanka,Port of Spain,6/6/1997,
+Australia,lost,36 runs,0,lost,2nd,Pakistan,Nottingham,6/19/2001,
+England,won,36 runs,0,lost,1st,Sri Lanka,Lord's,8/16/1998,
+New Zealand,lost,36 runs,0,won,2nd,Sri Lanka,Dambulla,11/16/2013,
+Pakistan,lost,36 runs,0,won,2nd,Sri Lanka,Dambulla,7/30/2009,
+Pakistan,won,36 runs,0,won,1st,Australia,Nottingham,6/19/2001,
+Sri Lanka,lost,36 runs,0,won,2nd,England,Lord's,8/16/1998,
+Sri Lanka,won,36 runs,0,lost,1st,New Zealand,Dambulla,11/16/2013,
+Sri Lanka,won,36 runs,0,lost,1st,Pakistan,Dambulla,7/30/2009,
+Australia,lost,37 runs,0,lost,2nd,India,Gwalior,10/26/2003,
+Australia,won,37 runs,0,won,1st,India,Kolkata,11/18/2003,
+Australia,won,37 runs,0,won,1st,South Africa,Bloemfontein,3/30/2002,
+India,lost,37 runs,0,lost,2nd,Australia,Kolkata,11/18/2003,
+India,won,37 runs,0,won,1st,Australia,Gwalior,10/26/2003,
+Pakistan,lost,37 runs,0,won,2nd,West Indies,Providence,7/16/2013,
+South Africa,lost,37 runs,0,lost,2nd,Australia,Bloemfontein,3/30/2002,
+South Africa,lost,37 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),8/22/2004,
+South Africa,lost,37 runs,0,won,2nd,Sri Lanka,Galle,7/6/2000,
+Sri Lanka,won,37 runs,0,lost,1st,South Africa,Galle,7/6/2000,
+Sri Lanka,won,37 runs,0,won,1st,South Africa,Colombo (RPS),8/22/2004,
+West Indies,won,37 runs,0,lost,1st,Pakistan,Providence,7/16/2013,
+England,lost,38 runs,0,lost,2nd,Pakistan,Lord's,9/20/2010,
+England,lost,38 runs,0,won,2nd,India,Leeds,9/2/2007,
+England,lost,38 runs,0,won,2nd,South Africa,Johannesburg,2/13/2000,
+India,lost,38 runs,0,lost,2nd,South Africa,Sharjah,4/19/1996,
+India,lost,38 runs,0,won,2nd,Pakistan,Sharjah,4/12/1996,
+India,won,38 runs,0,lost,1st,England,Leeds,9/2/2007,
+New Zealand,won,38 runs,0,lost,1st,Sri Lanka,Johannesburg,9/27/2009,Daniel Vettori (NZ)
+Pakistan,won,38 runs,0,lost,1st,India,Sharjah,4/12/1996,
+Pakistan,won,38 runs,0,won,1st,England,Lord's,9/20/2010,
+South Africa,won,38 runs,0,lost,1st,England,Johannesburg,2/13/2000,
+South Africa,won,38 runs,0,won,1st,India,Sharjah,4/19/1996,
+Sri Lanka,lost,38 runs,0,won,2nd,New Zealand,Johannesburg,9/27/2009,Daniel Vettori (NZ)
+Australia,lost,39 runs,0,lost,2nd,South Africa,Perth,1/30/2009,
+Australia,lost,39 runs,0,lost,2nd,West Indies,Port of Spain,5/25/2003,
+Australia,won,39 runs,0,lost,1st,England,Lord's,9/6/2009,
+Australia,won,39 runs,0,lost,1st,West Indies,Melbourne,2/9/2001,
+Australia,won,39 runs,0,won,1st,West Indies,Canberra,2/6/2013,
+England,lost,39 runs,0,won,2nd,Australia,Lord's,9/6/2009,
+England,lost,39 runs,0,won,2nd,India,Delhi,3/28/2006,
+India,lost,39 runs,0,lost,2nd,South Africa,Bloemfontein,1/23/1997,
+India,won,39 runs,0,lost,1st,England,Delhi,3/28/2006,
+India,won,39 runs,0,won,1st,Pakistan,Bangalore,3/9/1996,
+Pakistan,lost,39 runs,0,lost,2nd,India,Bangalore,3/9/1996,
+Pakistan,lost,39 runs,0,lost,2nd,Sri Lanka,Tangier,8/17/2002,
+Pakistan,won,39 runs,0,won,1st,Sri Lanka,Dhaka,6/7/2000,
+South Africa,won,39 runs,0,won,1st,Australia,Perth,1/30/2009,
+South Africa,won,39 runs,0,won,1st,India,Bloemfontein,1/23/1997,
+Sri Lanka,lost,39 runs,0,lost,2nd,Pakistan,Dhaka,6/7/2000,
+Sri Lanka,won,39 runs,0,lost,1st,West Indies,Port of Spain,7/7/2013,
+Sri Lanka,won,39 runs,0,won,1st,Pakistan,Tangier,8/17/2002,
+West Indies,lost,39 runs,0,lost,2nd,Australia,Canberra,2/6/2013,
+West Indies,lost,39 runs,0,won,2nd,Australia,Melbourne,2/9/2001,
+West Indies,lost,39 runs,0,won,2nd,Sri Lanka,Port of Spain,7/7/2013,
+West Indies,won,39 runs,0,won,1st,Australia,Port of Spain,5/25/2003,
+Australia,won,4 runs,0,lost,1st,England,The Oval,9/4/2009,
+Australia,won,4 runs,0,won,1st,India,Vadodara,10/25/2009,
+England,lost,4 runs,0,won,2nd,Australia,The Oval,9/4/2009,
+India,lost,4 runs,0,lost,2nd,Australia,Vadodara,10/25/2009,
+India,won,4 runs,0,won,1st,Sri Lanka,Colombo (RPS),7/27/2004,
+New Zealand,won,4 runs,0,lost,1st,West Indies,Georgetown,4/3/1996,Lee Germon (NZ)
+New Zealand,won,4 runs,0,won,1st,Pakistan,Wellington,1/17/2004,Stephen Fleming (NZ)
+Pakistan,lost,4 runs,0,lost,2nd,New Zealand,Wellington,1/17/2004,Stephen Fleming (NZ)
+South Africa,lost,4 runs,0,won,2nd,Sri Lanka,Johannesburg,1/17/2001,
+South Africa,won,4 runs,0,lost,2nd,Sri Lanka,Bloemfontein,1/17/2012,
+Sri Lanka,lost,4 runs,0,lost,2nd,India,Colombo (RPS),7/27/2004,
+Sri Lanka,lost,4 runs,0,won,1st,South Africa,Bloemfontein,1/17/2012,
+Sri Lanka,won,4 runs,0,lost,1st,South Africa,Johannesburg,1/17/2001,
+West Indies,lost,4 runs,0,won,2nd,New Zealand,Georgetown,4/3/1996,Lee Germon (NZ)
+India,lost,4 wickets,0,won,1st,West Indies,Jamshedpur,11/6/2002,
+New Zealand,lost,4 wickets,0,won,1st,West Indies,Kingstown,6/16/2002,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,0,lost,2nd,Sri Lanka,Hambantota,11/12/2013,
+Sri Lanka,lost,4 wickets,0,won,1st,New Zealand,Hambantota,11/12/2013,
+West Indies,won,4 wickets,0,lost,2nd,India,Jamshedpur,11/6/2002,
+West Indies,won,4 wickets,0,lost,2nd,New Zealand,Kingstown,6/16/2002,Stephen Fleming (NZ)
+India,lost,4 wickets,1,won,1st,Pakistan,Mohali,11/8/2007,
+India,lost,4 wickets,1,won,1st,West Indies,Basseterre,5/23/2006,
+India,won,4 wickets,1,lost,2nd,South Africa,Vadodara,3/17/2000,
+New Zealand,won,4 wickets,1,lost,2nd,South Africa,Auckland,3/24/2015,Brendon McCullum (NZ)
+New Zealand,won,4 wickets,1,won,2nd,West Indies,Port of Spain,3/29/1996,Lee Germon (NZ)
+Pakistan,won,4 wickets,1,lost,2nd,India,Mohali,11/8/2007,
+Pakistan,won,4 wickets,1,lost,2nd,West Indies,Abu Dhabi,11/12/2008,
+Pakistan,won,4 wickets,1,won,2nd,Sri Lanka,Hambantota,8/23/2014,
+Pakistan,won,4 wickets,1,won,2nd,West Indies,Gros Islet,7/24/2013,
+South Africa,lost,4 wickets,1,won,1st,India,Vadodara,3/17/2000,
+South Africa,lost,4 wickets,1,won,1st,New Zealand,Auckland,3/24/2015,Brendon McCullum (NZ)
+Sri Lanka,lost,4 wickets,1,lost,1st,Pakistan,Hambantota,8/23/2014,
+West Indies,lost,4 wickets,1,lost,1st,New Zealand,Port of Spain,3/29/1996,Lee Germon (NZ)
+West Indies,lost,4 wickets,1,lost,1st,Pakistan,Gros Islet,7/24/2013,
+West Indies,lost,4 wickets,1,won,1st,Pakistan,Abu Dhabi,11/12/2008,
+West Indies,won,4 wickets,1,lost,2nd,India,Basseterre,5/23/2006,
+Australia,lost,4 wickets,2,lost,1st,New Zealand,Melbourne (Docklands),12/5/2004,Stephen Fleming (NZ)
+Australia,lost,4 wickets,2,won,1st,India,Adelaide,2/12/2012,
+India,lost,4 wickets,2,lost,1st,New Zealand,Nairobi (Gym),10/15/2000,Stephen Fleming (NZ)
+India,won,4 wickets,2,lost,2nd,Australia,Adelaide,2/12/2012,
+New Zealand,won,4 wickets,2,won,2nd,Australia,Melbourne (Docklands),12/5/2004,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,2,won,2nd,India,Nairobi (Gym),10/15/2000,Stephen Fleming (NZ)
+South Africa,won,4 wickets,2,lost,2nd,West Indies,Johannesburg,2/4/2004,
+West Indies,lost,4 wickets,2,won,1st,South Africa,Johannesburg,2/4/2004,
+Australia,lost,4 wickets,3,won,1st,England,Melbourne,2/9/2007,
+Australia,won,4 wickets,3,lost,2nd,India,Perth,1/30/2000,
+Australia,won,4 wickets,3,won,2nd,India,Mohali,10/19/2013,
+England,won,4 wickets,3,lost,2nd,Australia,Melbourne,2/9/2007,
+England,won,4 wickets,3,lost,2nd,Pakistan,Leeds,9/12/2010,
+England,won,4 wickets,3,lost,2nd,Sri Lanka,Brisbane,1/11/1999,
+India,lost,4 wickets,3,lost,1st,Australia,Mohali,10/19/2013,
+India,lost,4 wickets,3,lost,1st,South Africa,Belfast,6/26/2007,
+India,lost,4 wickets,3,won,1st,Australia,Perth,1/30/2000,
+India,won,4 wickets,3,lost,2nd,Pakistan,Karachi,9/30/1997,
+Pakistan,lost,4 wickets,3,won,1st,England,Leeds,9/12/2010,
+Pakistan,lost,4 wickets,3,won,1st,India,Karachi,9/30/1997,
+South Africa,won,4 wickets,3,won,2nd,India,Belfast,6/26/2007,
+Sri Lanka,lost,4 wickets,3,won,1st,England,Brisbane,1/11/1999,
+Sri Lanka,won,4 wickets,3,lost,2nd,West Indies,Bridgetown,6/8/2003,
+West Indies,lost,4 wickets,3,won,1st,Sri Lanka,Bridgetown,6/8/2003,
+Australia,lost,4 wickets,4,won,1st,West Indies,Perth,1/12/1997,
+England,won,4 wickets,4,lost,2nd,Pakistan,Dubai (DSC),2/21/2012,
+New Zealand,lost,4 wickets,4,lost,1st,South Africa,Port Elizabeth,10/30/2005,Stephen Fleming (NZ)
+Pakistan,lost,4 wickets,4,won,1st,England,Dubai (DSC),2/21/2012,
+Pakistan,lost,4 wickets,4,won,1st,Sri Lanka,Sharjah,4/11/1997,
+South Africa,won,4 wickets,4,won,2nd,New Zealand,Port Elizabeth,10/30/2005,Stephen Fleming (NZ)
+Sri Lanka,won,4 wickets,4,lost,2nd,Pakistan,Sharjah,4/11/1997,
+West Indies,won,4 wickets,4,lost,2nd,Australia,Perth,1/12/1997,
+Australia,lost,4 wickets,5,won,1st,New Zealand,Melbourne,1/21/1998,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,5,lost,2nd,Australia,Melbourne,1/21/1998,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,5,lost,2nd,South Africa,Brisbane,1/19/2002,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,5,won,2nd,Pakistan,Auckland,1/3/2004,
+New Zealand,won,4 wickets,5,won,2nd,Pakistan,Auckland,1/3/2004,Stephen Fleming (NZ)
+Pakistan,lost,4 wickets,5,lost,1st,New Zealand,Auckland,1/3/2004,Stephen Fleming (NZ)
+South Africa,lost,4 wickets,5,won,1st,New Zealand,Brisbane,1/19/2002,
+South Africa,lost,4 wickets,5,won,1st,New Zealand,Brisbane,1/19/2002,Stephen Fleming (NZ)
+Australia,won,4 wickets,6,lost,2nd,India,Melbourne,1/18/2015,
+England,lost,4 wickets,6,won,1st,India,Faridabad,3/31/2006,
+India,lost,4 wickets,6,won,1st,Australia,Melbourne,1/18/2015,
+India,lost,4 wickets,6,won,1st,New Zealand,Sharjah,4/20/1998,Stephen Fleming (NZ)
+India,won,4 wickets,6,lost,2nd,England,Faridabad,3/31/2006,
+New Zealand,won,4 wickets,6,lost,2nd,India,Sharjah,4/20/1998,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,6,lost,2nd,Pakistan,Nairobi (Gym),10/11/2000,Stephen Fleming (NZ)
+Pakistan,lost,4 wickets,6,won,1st,New Zealand,Nairobi (Gym),10/11/2000,Stephen Fleming (NZ)
+Australia,lost,4 wickets,7,won,1st,West Indies,Jaipur,3/4/1996,
+Australia,won,4 wickets,7,lost,2nd,Sri Lanka,Brisbane,1/15/2003,
+England,won,4 wickets,7,lost,2nd,India,Manchester,5/26/1996,
+England,won,4 wickets,7,lost,2nd,New Zealand,Christchurch,2/20/1997,Lee Germon (NZ)
+India,lost,4 wickets,7,won,1st,England,Manchester,5/26/1996,
+New Zealand,lost,4 wickets,7,won,1st,England,Christchurch,2/20/1997,Lee Germon (NZ)
+Sri Lanka,lost,4 wickets,7,won,1st,Australia,Brisbane,1/15/2003,
+West Indies,won,4 wickets,7,lost,2nd,Australia,Jaipur,3/4/1996,
+Australia,won,4 wickets,8,lost,2nd,India,Delhi,4/14/1998,
+India,lost,4 wickets,8,won,1st,Australia,Delhi,4/14/1998,
+Australia,lost,4 wickets,9,won,1st,South Africa,Melbourne,1/13/2002,
+Australia,won,4 wickets,9,lost,2nd,West Indies,Bridgetown,4/24/1999,
+England,won,4 wickets,9,won,2nd,Pakistan,Lord's,6/22/2003,
+India,lost,4 wickets,9,lost,1st,Sri Lanka,Dhaka,1/13/2010,
+New Zealand,lost,4 wickets,9,lost,1st,Pakistan,Sharjah,11/13/1996,Lee Germon (NZ)
+Pakistan,lost,4 wickets,9,lost,1st,England,Lord's,6/22/2003,
+Pakistan,won,4 wickets,9,won,2nd,New Zealand,Sharjah,11/13/1996,Lee Germon (NZ)
+South Africa,won,4 wickets,9,lost,2nd,Australia,Melbourne,1/13/2002,
+Sri Lanka,won,4 wickets,9,won,2nd,India,Dhaka,1/13/2010,
+West Indies,lost,4 wickets,9,won,1st,Australia,Bridgetown,4/24/1999,
+Australia,won,4 wickets,10,lost,2nd,England,Nottingham,9/15/2009,
+Australia,won,4 wickets,10,lost,2nd,Pakistan,Sharjah,8/28/2012,
+England,lost,4 wickets,10,won,1st,Australia,Nottingham,9/15/2009,
+Pakistan,lost,4 wickets,10,won,1st,Australia,Sharjah,8/28/2012,
+India,won,4 wickets,11,won,2nd,Sri Lanka,Birmingham,7/6/2002,
+New Zealand,won,4 wickets,11,lost,2nd,Pakistan,Dunedin,2/28/2001,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,11,lost,2nd,Sri Lanka,Nelson,1/20/2015,Brendon McCullum (NZ)
+Pakistan,lost,4 wickets,11,won,1st,New Zealand,Dunedin,2/28/2001,Stephen Fleming (NZ)
+Pakistan,won,4 wickets,11,lost,2nd,Sri Lanka,Jaipur,10/17/2006,
+Sri Lanka,lost,4 wickets,11,lost,1st,India,Birmingham,7/6/2002,
+Sri Lanka,lost,4 wickets,11,won,1st,New Zealand,Nelson,1/20/2015,Brendon McCullum (NZ)
+Sri Lanka,lost,4 wickets,11,won,1st,Pakistan,Jaipur,10/17/2006,
+Australia,won,4 wickets,12,lost,2nd,India,Margao,4/6/2001,
+Australia,won,4 wickets,12,lost,2nd,Pakistan,Hobart,1/16/2005,
+England,won,4 wickets,12,lost,2nd,South Africa,The Oval,8/31/2012,
+India,lost,4 wickets,12,won,1st,Australia,Margao,4/6/2001,
+India,lost,4 wickets,12,won,1st,Sri Lanka,Dambulla,8/3/2005,
+Pakistan,lost,4 wickets,12,won,1st,Australia,Hobart,1/16/2005,
+Pakistan,won,4 wickets,12,lost,2nd,Sri Lanka,Kimberley,4/7/1998,
+South Africa,lost,4 wickets,12,won,1st,England,The Oval,8/31/2012,
+Sri Lanka,lost,4 wickets,12,won,1st,Pakistan,Kimberley,4/7/1998,
+Sri Lanka,won,4 wickets,12,lost,2nd,India,Dambulla,8/3/2005,
+Australia,lost,4 wickets,13,lost,1st,South Africa,Johannesburg,4/16/2000,
+South Africa,won,4 wickets,13,won,2nd,Australia,Johannesburg,4/16/2000,
+India,lost,4 wickets,14,lost,1st,West Indies,Singapore,9/8/1999,
+South Africa,lost,4 wickets,14,won,1st,Sri Lanka,Dambulla,8/25/2004,
+Sri Lanka,won,4 wickets,14,lost,2nd,South Africa,Dambulla,8/25/2004,
+West Indies,won,4 wickets,14,won,2nd,India,Singapore,9/8/1999,
+Australia,won,4 wickets,15,lost,2nd,England,Adelaide,1/19/2003,
+England,lost,4 wickets,15,won,1st,Australia,Adelaide,1/19/2003,
+India,lost,4 wickets,15,won,1st,New Zealand,Cuttack,11/6/2003,Stephen Fleming (NZ)
+New Zealand,won,4 wickets,15,lost,2nd,India,Cuttack,11/6/2003,Stephen Fleming (NZ)
+England,lost,4 wickets,16,won,1st,India,Kochi,4/6/2006,
+India,lost,4 wickets,16,lost,1st,Pakistan,Peshawar,3/19/2004,
+India,lost,4 wickets,16,won,1st,Pakistan,Sharjah,12/14/1997,
+India,lost,4 wickets,16,won,1st,South Africa,Hove,5/15/1999,
+India,won,4 wickets,16,lost,2nd,England,Kochi,4/6/2006,
+Pakistan,won,4 wickets,16,lost,2nd,India,Sharjah,12/14/1997,
+Pakistan,won,4 wickets,16,won,2nd,India,Peshawar,3/19/2004,
+South Africa,won,4 wickets,16,lost,2nd,India,Hove,5/15/1999,
+South Africa,won,4 wickets,16,lost,2nd,Sri Lanka,Port Elizabeth,12/15/2000,
+Sri Lanka,lost,4 wickets,16,won,1st,South Africa,Port Elizabeth,12/15/2000,
+England,lost,4 wickets,17,lost,1st,West Indies,Gros Islet,5/2/2004,
+West Indies,won,4 wickets,17,won,2nd,England,Gros Islet,5/2/2004,
+Australia,lost,4 wickets,18,lost,1st,Sri Lanka,Colombo (RPS),8/22/2011,
+Australia,won,4 wickets,18,lost,2nd,England,Sydney,2/5/1999,
+England,lost,4 wickets,18,won,1st,Australia,Sydney,2/5/1999,
+South Africa,won,4 wickets,18,won,2nd,West Indies,Dhaka,11/1/1998,
+Sri Lanka,won,4 wickets,18,won,2nd,Australia,Colombo (RPS),8/22/2011,
+West Indies,lost,4 wickets,18,lost,1st,South Africa,Dhaka,11/1/1998,
+England,lost,4 wickets,20,won,1st,India,Chennai,1/25/2002,
+India,won,4 wickets,20,lost,2nd,England,Chennai,1/25/2002,
+India,won,4 wickets,20,lost,2nd,Sri Lanka,Perth,2/8/2012,
+Sri Lanka,lost,4 wickets,20,won,1st,India,Perth,2/8/2012,
+England,lost,4 wickets,21,won,1st,New Zealand,Christchurch,2/13/2002,Stephen Fleming (NZ)
+New Zealand,lost,4 wickets,21,won,1st,Pakistan,Sharjah,11/10/1996,Lee Germon (NZ)
+New Zealand,won,4 wickets,21,lost,2nd,England,Christchurch,2/13/2002,Stephen Fleming (NZ)
+Pakistan,won,4 wickets,21,lost,2nd,New Zealand,Sharjah,11/10/1996,Lee Germon (NZ)
+Pakistan,won,4 wickets,23,lost,2nd,West Indies,Sharjah,2/14/2002,
+West Indies,lost,4 wickets,23,won,1st,Pakistan,Sharjah,2/14/2002,
+Australia,lost,4 wickets,24,won,1st,England,Southampton,6/22/2010,
+Australia,won,4 wickets,24,lost,2nd,England,Sydney,1/23/2011,
+England,lost,4 wickets,24,won,1st,Australia,Sydney,1/23/2011,
+England,won,4 wickets,24,lost,2nd,Australia,Southampton,6/22/2010,
+New Zealand,won,4 wickets,24,lost,2nd,Pakistan,Sharjah,12/12/2014,
+Pakistan,lost,4 wickets,24,won,1st,New Zealand,Sharjah,12/12/2014,
+Australia,lost,4 wickets,25,won,1st,Sri Lanka,Colombo (RPS),8/30/1996,
+England,won,4 wickets,25,lost,2nd,West Indies,Sharjah,12/13/1997,
+Sri Lanka,won,4 wickets,25,lost,2nd,Australia,Colombo (RPS),8/30/1996,
+West Indies,lost,4 wickets,25,won,1st,England,Sharjah,12/13/1997,
+India,won,4 wickets,26,won,2nd,Sri Lanka,Pune,11/3/2005,
+Sri Lanka,lost,4 wickets,26,lost,1st,India,Pune,11/3/2005,
+Australia,lost,4 wickets,27,won,1st,Pakistan,Sydney,1/1/1997,
+Pakistan,won,4 wickets,27,lost,2nd,Australia,Sydney,1/1/1997,
+Australia,lost,4 wickets,28,won,1st,England,Cardiff,6/24/2010,
+England,won,4 wickets,28,lost,2nd,Australia,Cardiff,6/24/2010,
+India,won,4 wickets,28,lost,2nd,Sri Lanka,The Oval,6/30/2002,
+New Zealand,won,4 wickets,28,lost,2nd,Pakistan,Dambulla,5/23/2003,Stephen Fleming (NZ)
+Pakistan,lost,4 wickets,28,won,1st,New Zealand,Dambulla,5/23/2003,Stephen Fleming (NZ)
+Pakistan,won,4 wickets,28,won,2nd,Sri Lanka,Colombo (SSC),3/22/2006,
+Sri Lanka,lost,4 wickets,28,lost,1st,Pakistan,Colombo (SSC),3/22/2006,
+Sri Lanka,lost,4 wickets,28,won,1st,India,The Oval,6/30/2002,
+Pakistan,won,4 wickets,29,lost,2nd,West Indies,Port of Spain,4/23/2000,
+West Indies,lost,4 wickets,29,won,1st,Pakistan,Port of Spain,4/23/2000,
+India,won,4 wickets,31,lost,2nd,West Indies,Port of Spain,6/6/2011,
+West Indies,lost,4 wickets,31,won,1st,India,Port of Spain,6/6/2011,
+Pakistan,won,4 wickets,32,won,2nd,Sri Lanka,Colombo (RPS),3/19/2006,
+Sri Lanka,lost,4 wickets,32,lost,1st,Pakistan,Colombo (RPS),3/19/2006,
+Australia,lost,4 wickets,35,won,1st,Pakistan,Dubai (DSC),4/22/2009,
+Pakistan,won,4 wickets,35,lost,2nd,Australia,Dubai (DSC),4/22/2009,
+Australia,lost,4 wickets,54,won,1st,Pakistan,Colombo (RPS),3/19/2011,
+Pakistan,won,4 wickets,54,lost,2nd,Australia,Colombo (RPS),3/19/2011,
+South Africa,won,4 wickets,56,won,2nd,Sri Lanka,Lahore,11/8/1997,
+Sri Lanka,lost,4 wickets,56,lost,1st,South Africa,Lahore,11/8/1997,
+Australia,lost,4 wickets,60,lost,1st,England,Chester-le-Street,9/20/2009,
+England,won,4 wickets,60,won,2nd,Australia,Chester-le-Street,9/20/2009,
+India,won,4 wickets,65,lost,2nd,West Indies,Perth,3/6/2015,
+West Indies,lost,4 wickets,65,won,1st,India,Perth,3/6/2015,
+England,won,4 wickets,66,lost,2nd,South Africa,Birmingham,7/8/2003,
+South Africa,lost,4 wickets,66,won,1st,England,Birmingham,7/8/2003,
+Australia,won,4 wickets,68,lost,2nd,England,Brisbane,1/19/2007,
+England,lost,4 wickets,68,won,1st,Australia,Brisbane,1/19/2007,
+Pakistan,lost,4 wickets,68,lost,1st,South Africa,Centurion,11/30/2013,
+South Africa,won,4 wickets,68,won,2nd,Pakistan,Centurion,11/30/2013,
+Pakistan,won,4 wickets,70,won,2nd,West Indies,Sydney,1/18/1997,
+West Indies,lost,4 wickets,70,lost,1st,Pakistan,Sydney,1/18/1997,
+England,lost,4 wickets,74,won,1st,West Indies,Kingstown,4/5/1998,
+West Indies,won,4 wickets,74,lost,2nd,England,Kingstown,4/5/1998,
+New Zealand,won,4 wickets,76,lost,2nd,West Indies,Napier,1/6/2000,Stephen Fleming (NZ)
+West Indies,lost,4 wickets,76,won,1st,New Zealand,Napier,1/6/2000,Stephen Fleming (NZ)
+England,lost,4 wickets,123,lost,1st,India,Jaipur,10/15/2006,
+India,won,4 wickets,123,won,2nd,England,Jaipur,10/15/2006,
+New Zealand,won,4 wickets,129,won,2nd,Sri Lanka,Christchurch,1/2/2007,Daniel Vettori (NZ)
+Sri Lanka,lost,4 wickets,129,lost,1st,New Zealand,Christchurch,1/2/2007,Daniel Vettori (NZ)
+England,lost,4 wickets,137,lost,1st,New Zealand,Johannesburg,9/29/2009,Daniel Vettori (NZ)
+New Zealand,won,4 wickets,137,won,2nd,England,Johannesburg,9/29/2009,Daniel Vettori (NZ)
+Australia,lost,4 wickets,180,won,1st,Sri Lanka,Brisbane,1/18/2013,
+Sri Lanka,won,4 wickets,180,lost,2nd,Australia,Brisbane,1/18/2013,
+Australia,won,40 runs,0,won,1st,Pakistan,Adelaide,1/26/2010,
+Australia,won,40 runs,0,won,1st,Sri Lanka,Colombo (RPS),2/27/2004,
+India,won,40 runs,0,lost,1st,New Zealand,Guwahati,11/28/2010,Ross Taylor (NZ)
+India,won,40 runs,0,lost,1st,Pakistan,Lahore,3/24/2004,
+New Zealand,lost,40 runs,0,won,2nd,India,Guwahati,11/28/2010,Ross Taylor (NZ)
+Pakistan,lost,40 runs,0,lost,2nd,Australia,Adelaide,1/26/2010,
+Pakistan,lost,40 runs,0,won,2nd,India,Lahore,3/24/2004,
+Pakistan,won,40 runs,0,won,1st,West Indies,Gros Islet,5/21/2005,
+Sri Lanka,lost,40 runs,0,lost,2nd,Australia,Colombo (RPS),2/27/2004,
+West Indies,lost,40 runs,0,lost,2nd,Pakistan,Gros Islet,5/21/2005,
+Australia,lost,41 runs,0,lost,2nd,India,Kochi,4/1/1998,
+Australia,won,41 runs,0,lost,1st,India,Colombo (SSC),8/28/1999,
+England,won,41 runs,0,lost,1st,India,Leeds,9/5/2014,
+India,lost,41 runs,0,won,2nd,Australia,Colombo (SSC),8/28/1999,
+India,lost,41 runs,0,won,2nd,England,Leeds,9/5/2014,
+India,lost,41 runs,0,won,2nd,West Indies,Sharjah,12/16/1997,
+India,won,41 runs,0,won,1st,Australia,Kochi,4/1/1998,
+India,won,41 runs,0,won,1st,South Africa,Centurion,10/10/2001,
+New Zealand,lost,41 runs,0,won,2nd,Pakistan,Hamilton,2/3/2011,Ross Taylor (NZ)
+New Zealand,lost,41 runs,0,won,2nd,Pakistan,Sharjah,11/15/1996,Lee Germon (NZ)
+Pakistan,lost,41 runs,0,lost,2nd,Sri Lanka,Sharjah,4/8/2002,
+Pakistan,won,41 runs,0,lost,1st,New Zealand,Hamilton,2/3/2011,Ross Taylor (NZ)
+Pakistan,won,41 runs,0,lost,1st,New Zealand,Sharjah,11/15/1996,Lee Germon (NZ)
+South Africa,lost,41 runs,0,lost,2nd,India,Centurion,10/10/2001,
+Sri Lanka,won,41 runs,0,won,1st,Pakistan,Sharjah,4/8/2002,
+West Indies,won,41 runs,0,lost,1st,India,Sharjah,12/16/1997,
+Australia,lost,42 runs,0,won,2nd,West Indies,Gros Islet,3/23/2012,
+Australia,won,42 runs,0,won,1st,England,Lord's,7/3/2010,
+England,lost,42 runs,0,lost,2nd,Australia,Lord's,7/3/2010,
+England,won,42 runs,0,lost,1st,India,Birmingham,8/27/2007,
+England,won,42 runs,0,won,1st,Pakistan,Lahore,12/10/2005,
+India,lost,42 runs,0,lost,2nd,West Indies,Singapore,9/5/1999,
+India,lost,42 runs,0,won,2nd,England,Birmingham,8/27/2007,
+Pakistan,lost,42 runs,0,lost,2nd,England,Lahore,12/10/2005,
+Pakistan,won,42 runs,0,lost,1st,South Africa,Lahore,10/5/2003,
+Pakistan,won,42 runs,0,won,1st,West Indies,Toronto,9/18/1999,
+South Africa,lost,42 runs,0,won,2nd,Pakistan,Lahore,10/5/2003,
+West Indies,lost,42 runs,0,lost,2nd,Pakistan,Toronto,9/18/1999,
+West Indies,won,42 runs,0,lost,1st,Australia,Gros Islet,3/23/2012,
+West Indies,won,42 runs,0,won,1st,India,Singapore,9/5/1999,
+Australia,won,43 runs,0,won,1st,Sri Lanka,Melbourne,2/7/1999,
+England,won,43 runs,0,lost,1st,New Zealand,Napier,2/20/2002,Stephen Fleming (NZ)
+England,won,43 runs,0,won,1st,Sri Lanka,Brisbane,12/17/2002,
+India,lost,43 runs,0,lost,2nd,New Zealand,Rajkot,11/5/1999,Stephen Fleming (NZ)
+New Zealand,lost,43 runs,0,won,2nd,England,Napier,2/20/2002,Stephen Fleming (NZ)
+New Zealand,lost,43 runs,0,won,2nd,Pakistan,Christchurch,1/29/2011,Ross Taylor (NZ)
+New Zealand,won,43 runs,0,won,1st,India,Rajkot,11/5/1999,Stephen Fleming (NZ)
+Pakistan,lost,43 runs,0,lost,2nd,West Indies,Sharjah,12/12/1997,
+Pakistan,won,43 runs,0,lost,1st,New Zealand,Christchurch,1/29/2011,Ross Taylor (NZ)
+Pakistan,won,43 runs,0,lost,1st,Sri Lanka,Singapore,4/7/1996,
+South Africa,lost,43 runs,0,won,2nd,West Indies,East London,1/24/1999,
+Sri Lanka,lost,43 runs,0,lost,2nd,Australia,Melbourne,2/7/1999,
+Sri Lanka,lost,43 runs,0,lost,2nd,England,Brisbane,12/17/2002,
+Sri Lanka,lost,43 runs,0,won,2nd,Pakistan,Singapore,4/7/1996,
+West Indies,won,43 runs,0,lost,1st,South Africa,East London,1/24/1999,
+West Indies,won,43 runs,0,won,1st,Pakistan,Sharjah,12/12/1997,
+Australia,lost,44 runs,0,won,2nd,India,Dhaka,10/28/1998,
+Australia,lost,44 runs,0,won,2nd,West Indies,Kingstown,4/11/1999,
+Australia,won,44 runs,0,lost,1st,New Zealand,Guwahati,11/9/2003,Stephen Fleming (NZ)
+England,won,44 runs,0,won,1st,Sri Lanka,Nottingham,6/27/2002,
+India,lost,44 runs,0,lost,2nd,Pakistan,Dhaka,6/3/2000,
+India,won,44 runs,0,lost,1st,Australia,Dhaka,10/28/1998,
+New Zealand,lost,44 runs,0,won,2nd,Australia,Guwahati,11/9/2003,Stephen Fleming (NZ)
+Pakistan,lost,44 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),6/16/2012,
+Pakistan,won,44 runs,0,won,1st,India,Dhaka,6/3/2000,
+Sri Lanka,lost,44 runs,0,lost,2nd,England,Nottingham,6/27/2002,
+Sri Lanka,won,44 runs,0,won,1st,Pakistan,Colombo (RPS),6/16/2012,
+West Indies,won,44 runs,0,lost,1st,Australia,Kingstown,4/11/1999,
+Australia,lost,45 runs,0,lost,2nd,Pakistan,Brisbane,1/9/2000,
+Australia,lost,45 runs,0,lost,2nd,South Africa,Melbourne,12/9/1997,
+Australia,won,45 runs,0,lost,1st,South Africa,Centurion,3/24/2002,
+Australia,won,45 runs,0,lost,1st,Sri Lanka,Perth,1/31/1999,
+Pakistan,lost,45 runs,0,lost,2nd,South Africa,Lahore,10/18/2007,
+Pakistan,won,45 runs,0,won,1st,Australia,Brisbane,1/9/2000,
+South Africa,lost,45 runs,0,won,2nd,Australia,Centurion,3/24/2002,
+South Africa,won,45 runs,0,won,1st,Australia,Melbourne,12/9/1997,
+South Africa,won,45 runs,0,won,1st,Pakistan,Lahore,10/18/2007,
+Sri Lanka,lost,45 runs,0,won,2nd,Australia,Perth,1/31/1999,
+Australia,lost,46 runs,0,won,2nd,South Africa,Cape Town,4/2/1997,
+Australia,won,46 runs,0,lost,1st,England,Hobart,1/21/2011,
+Australia,won,46 runs,0,won,1st,West Indies,St George's,4/14/1999,
+England,lost,46 runs,0,lost,2nd,Sri Lanka,The Oval,6/20/2006,
+England,lost,46 runs,0,won,2nd,Australia,Hobart,1/21/2011,
+India,lost,46 runs,0,lost,2nd,South Africa,East London,10/19/2001,
+India,won,46 runs,0,lost,1st,Pakistan,Kanpur,11/11/2007,
+India,won,46 runs,0,lost,1st,Sri Lanka,Colombo (SSC),8/1/2001,
+India,won,46 runs,0,won,1st,Sri Lanka,Colombo (RPS),8/27/2008,
+India,won,46 runs,0,won,1st,Sri Lanka,Colombo (RPS),9/14/2009,
+New Zealand,lost,46 runs,0,lost,2nd,Pakistan,Sialkot,12/6/1996,Lee Germon (NZ)
+New Zealand,lost,46 runs,0,lost,2nd,Sri Lanka,Sharjah,4/14/2002,Stephen Fleming (NZ)
+New Zealand,lost,46 runs,0,won,2nd,Pakistan,Lahore,3/6/1996,Lee Germon (NZ)
+Pakistan,lost,46 runs,0,won,2nd,India,Kanpur,11/11/2007,
+Pakistan,won,46 runs,0,lost,1st,New Zealand,Lahore,3/6/1996,Lee Germon (NZ)
+Pakistan,won,46 runs,0,won,1st,New Zealand,Sialkot,12/6/1996,Lee Germon (NZ)
+South Africa,won,46 runs,0,lost,1st,Australia,Cape Town,4/2/1997,
+South Africa,won,46 runs,0,won,1st,India,East London,10/19/2001,
+Sri Lanka,lost,46 runs,0,lost,2nd,India,Colombo (RPS),8/27/2008,
+Sri Lanka,lost,46 runs,0,lost,2nd,India,Colombo (RPS),9/14/2009,
+Sri Lanka,lost,46 runs,0,won,2nd,India,Colombo (SSC),8/1/2001,
+Sri Lanka,won,46 runs,0,won,1st,England,The Oval,6/20/2006,
+Sri Lanka,won,46 runs,0,won,1st,New Zealand,Sharjah,4/14/2002,Stephen Fleming (NZ)
+West Indies,lost,46 runs,0,lost,2nd,Australia,St George's,4/14/1999,
+Australia,won,47 runs,0,lost,1st,South Africa,Johannesburg,4/17/2009,
+Australia,won,47 runs,0,won,1st,India,Hyderabad (Deccan),10/5/2007,
+India,lost,47 runs,0,lost,2nd,Australia,Hyderabad (Deccan),10/5/2007,
+India,lost,47 runs,0,lost,2nd,South Africa,Hyderabad (Deccan),10/17/1996,
+India,won,47 runs,0,won,1st,Pakistan,Manchester,6/8/1999,
+New Zealand,lost,47 runs,0,won,2nd,Sri Lanka,Bloemfontein,2/10/2003,Stephen Fleming (NZ)
+New Zealand,won,47 runs,0,lost,1st,South Africa,Adelaide,12/6/1997,Stephen Fleming (NZ)
+Pakistan,lost,47 runs,0,lost,2nd,India,Manchester,6/8/1999,
+South Africa,lost,47 runs,0,won,2nd,Australia,Johannesburg,4/17/2009,
+South Africa,lost,47 runs,0,won,2nd,New Zealand,Adelaide,12/6/1997,Stephen Fleming (NZ)
+South Africa,won,47 runs,0,won,1st,India,Hyderabad (Deccan),10/17/1996,
+Sri Lanka,won,47 runs,0,lost,1st,New Zealand,Bloemfontein,2/10/2003,Stephen Fleming (NZ)
+Australia,lost,48 runs,0,lost,2nd,England,Birmingham,6/8/2013,
+Australia,won,48 runs,0,lost,1st,New Zealand,Christchurch,2/26/2000,Stephen Fleming (NZ)
+Australia,won,48 runs,0,won,1st,Sri Lanka,Port Elizabeth,3/18/2003,
+England,won,48 runs,0,won,1st,Australia,Birmingham,6/8/2013,
+India,lost,48 runs,0,lost,2nd,South Africa,Port Elizabeth,1/21/2011,
+India,lost,48 runs,0,won,2nd,New Zealand,Guwahati,11/14/1999,Stephen Fleming (NZ)
+India,won,48 runs,0,won,1st,Pakistan,Adelaide,1/25/2000,
+India,won,48 runs,0,won,1st,West Indies,Delhi,10/11/2014,
+New Zealand,lost,48 runs,0,won,2nd,Australia,Christchurch,2/26/2000,Stephen Fleming (NZ)
+New Zealand,won,48 runs,0,lost,1st,India,Guwahati,11/14/1999,Stephen Fleming (NZ)
+Pakistan,lost,48 runs,0,lost,2nd,India,Adelaide,1/25/2000,
+South Africa,won,48 runs,0,won,1st,India,Port Elizabeth,1/21/2011,
+Sri Lanka,lost,48 runs,0,lost,2nd,Australia,Port Elizabeth,3/18/2003,
+West Indies,lost,48 runs,0,lost,2nd,India,Delhi,10/11/2014,
+Australia,won,49 runs,0,won,1st,England,Southampton,9/16/2013,
+England,lost,49 runs,0,lost,2nd,Australia,Southampton,9/16/2013,
+England,lost,49 runs,0,lost,2nd,India,Margao,4/3/2006,
+England,won,49 runs,0,lost,1st,Sri Lanka,Southampton,9/17/2004,
+India,won,49 runs,0,won,1st,England,Margao,4/3/2006,
+New Zealand,lost,49 runs,0,lost,2nd,Pakistan,Rawalpindi,12/7/2003,
+New Zealand,won,49 runs,0,won,1st,South Africa,Dhaka,3/25/2011,Daniel Vettori (NZ)
+Pakistan,won,49 runs,0,won,1st,New Zealand,Rawalpindi,12/7/2003,
+South Africa,lost,49 runs,0,lost,2nd,New Zealand,Dhaka,3/25/2011,Daniel Vettori (NZ)
+South Africa,lost,49 runs,0,won,2nd,Sri Lanka,Colombo (SSC),8/31/2004,
+Sri Lanka,lost,49 runs,0,lost,2nd,West Indies,Colombo (RPS),12/11/2001,
+Sri Lanka,lost,49 runs,0,won,2nd,England,Southampton,9/17/2004,
+Sri Lanka,won,49 runs,0,lost,1st,South Africa,Colombo (SSC),8/31/2004,
+West Indies,won,49 runs,0,won,1st,Sri Lanka,Colombo (RPS),12/11/2001,
+Australia,lost,5 runs,0,won,2nd,India,Mohali,11/3/1996,
+Australia,won,5 runs,0,lost,1st,South Africa,Hobart,1/18/2009,
+Australia,won,5 runs,0,lost,1st,Sri Lanka,Perth,2/10/2012,
+Australia,won,5 runs,0,won,1st,England,Adelaide,1/26/2014,
+Australia,won,5 runs,0,won,1st,England,Melbourne,1/25/2003,
+Australia,won,5 runs,0,won,1st,West Indies,Mohali,3/14/1996,
+England,lost,5 runs,0,lost,2nd,Australia,Adelaide,1/26/2014,
+England,lost,5 runs,0,lost,2nd,Australia,Melbourne,1/25/2003,
+England,lost,5 runs,0,won,2nd,India,Birmingham,6/23/2013,
+England,won,5 runs,0,won,1st,India,Mumbai,2/3/2002,
+India,lost,5 runs,0,lost,2nd,England,Mumbai,2/3/2002,
+India,lost,5 runs,0,lost,2nd,South Africa,Kanpur,10/11/2015,
+India,lost,5 runs,0,won,2nd,Sri Lanka,Rajkot,2/11/2007,
+India,won,5 runs,0,lost,1st,Australia,Mohali,11/3/1996,
+India,won,5 runs,0,lost,1st,England,Birmingham,6/23/2013,
+India,won,5 runs,0,lost,1st,Pakistan,Karachi,3/13/2004,
+New Zealand,won,5 runs,0,lost,1st,South Africa,Wellington,2/20/2004,Stephen Fleming (NZ)
+Pakistan,lost,5 runs,0,won,2nd,India,Karachi,3/13/2004,
+South Africa,lost,5 runs,0,won,2nd,Australia,Hobart,1/18/2009,
+South Africa,lost,5 runs,0,won,2nd,New Zealand,Wellington,2/20/2004,Stephen Fleming (NZ)
+South Africa,won,5 runs,0,won,1st,India,Kanpur,10/11/2015,
+Sri Lanka,lost,5 runs,0,won,2nd,Australia,Perth,2/10/2012,
+Sri Lanka,won,5 runs,0,lost,1st,India,Rajkot,2/11/2007,
+West Indies,lost,5 runs,0,lost,2nd,Australia,Mohali,3/14/1996,
+India,won,5 wickets,1,won,2nd,West Indies,Kingston,5/18/2006,
+New Zealand,lost,5 wickets,1,lost,1st,West Indies,Christchurch,1/3/2009,Daniel Vettori (NZ)
+West Indies,lost,5 wickets,1,lost,1st,India,Kingston,5/18/2006,
+West Indies,won,5 wickets,1,won,2nd,New Zealand,Christchurch,1/3/2009,Daniel Vettori (NZ)
+Australia,won,5 wickets,2,lost,2nd,South Africa,Leeds,6/13/1999,
+India,won,5 wickets,2,lost,2nd,Sri Lanka,Colombo (RPS),7/28/2012,
+New Zealand,lost,5 wickets,2,lost,1st,South Africa,Auckland,2/13/2004,Stephen Fleming (NZ)
+South Africa,lost,5 wickets,2,won,1st,Australia,Leeds,6/13/1999,
+South Africa,won,5 wickets,2,won,2nd,New Zealand,Auckland,2/13/2004,Stephen Fleming (NZ)
+Sri Lanka,lost,5 wickets,2,won,1st,India,Colombo (RPS),7/28/2012,
+Australia,won,5 wickets,3,lost,2nd,England,Bristol,6/10/2001,
+England,lost,5 wickets,3,won,1st,Australia,Bristol,6/10/2001,
+England,lost,5 wickets,4,won,1st,India,Mohali,10/20/2011,
+India,won,5 wickets,4,lost,2nd,England,Mohali,10/20/2011,
+England,won,5 wickets,5,won,2nd,Sri Lanka,Pallekele,12/10/2014,
+Sri Lanka,lost,5 wickets,5,lost,1st,England,Pallekele,12/10/2014,
+Australia,lost,5 wickets,6,won,1st,West Indies,Port of Spain,4/17/1999,
+Australia,won,5 wickets,6,lost,2nd,South Africa,Centurion,4/10/1997,
+India,lost,5 wickets,6,won,1st,New Zealand,Taupo,1/9/1999,Stephen Fleming (NZ)
+New Zealand,won,5 wickets,6,lost,2nd,India,Taupo,1/9/1999,Stephen Fleming (NZ)
+South Africa,lost,5 wickets,6,won,1st,Australia,Centurion,4/10/1997,
+West Indies,won,5 wickets,6,lost,2nd,Australia,Port of Spain,4/17/1999,
+Australia,lost,5 wickets,7,lost,1st,India,Visakhapatnam,10/20/2010,
+Australia,lost,5 wickets,7,won,1st,South Africa,Brisbane,1/15/2006,
+England,lost,5 wickets,7,won,1st,New Zealand,Dunedin,2/26/2002,Stephen Fleming (NZ)
+India,lost,5 wickets,7,lost,1st,South Africa,Hyderabad (Deccan),11/16/2005,
+India,lost,5 wickets,7,lost,1st,West Indies,Vadodara,11/18/2002,
+India,won,5 wickets,7,won,2nd,Australia,Visakhapatnam,10/20/2010,
+India,won,5 wickets,7,won,2nd,New Zealand,Bangalore,12/7/2010,Daniel Vettori (NZ)
+New Zealand,lost,5 wickets,7,lost,1st,India,Bangalore,12/7/2010,Daniel Vettori (NZ)
+New Zealand,lost,5 wickets,7,lost,1st,South Africa,Kimberley,10/28/2000,Stephen Fleming (NZ)
+New Zealand,won,5 wickets,7,lost,2nd,England,Dunedin,2/26/2002,Stephen Fleming (NZ)
+South Africa,lost,5 wickets,7,lost,1st,West Indies,The Oval,9/18/2004,
+South Africa,won,5 wickets,7,lost,2nd,Australia,Brisbane,1/15/2006,
+South Africa,won,5 wickets,7,won,2nd,India,Hyderabad (Deccan),11/16/2005,
+South Africa,won,5 wickets,7,won,2nd,New Zealand,Kimberley,10/28/2000,Stephen Fleming (NZ)
+West Indies,won,5 wickets,7,won,2nd,India,Vadodara,11/18/2002,
+West Indies,won,5 wickets,7,won,2nd,South Africa,The Oval,9/18/2004,
+Australia,lost,5 wickets,8,lost,1st,New Zealand,Auckland,2/18/2007,Stephen Fleming (NZ)
+Australia,won,5 wickets,8,lost,2nd,West Indies,Melbourne,12/6/1996,
+England,won,5 wickets,8,lost,2nd,Sri Lanka,Hambantota,12/3/2014,
+India,lost,5 wickets,8,won,1st,South Africa,Dhaka,4/18/2003,
+India,lost,5 wickets,8,won,1st,South Africa,Rajkot,10/29/1996,
+New Zealand,won,5 wickets,8,won,2nd,Australia,Auckland,2/18/2007,Stephen Fleming (NZ)
+Pakistan,lost,5 wickets,8,lost,1st,West Indies,Perth,1/10/1997,
+South Africa,lost,5 wickets,8,won,1st,Sri Lanka,Kimberley,1/20/2012,
+South Africa,won,5 wickets,8,lost,2nd,India,Dhaka,4/18/2003,
+South Africa,won,5 wickets,8,lost,2nd,India,Rajkot,10/29/1996,
+South Africa,won,5 wickets,8,won,2nd,Sri Lanka,East London,1/14/2012,
+Sri Lanka,lost,5 wickets,8,lost,1st,South Africa,East London,1/14/2012,
+Sri Lanka,lost,5 wickets,8,won,1st,England,Hambantota,12/3/2014,
+Sri Lanka,won,5 wickets,8,lost,2nd,South Africa,Kimberley,1/20/2012,
+West Indies,lost,5 wickets,8,won,1st,Australia,Melbourne,12/6/1996,
+West Indies,won,5 wickets,8,won,2nd,Pakistan,Perth,1/10/1997,
+Australia,won,5 wickets,9,lost,2nd,Pakistan,Brisbane,1/22/2010,
+Australia,won,5 wickets,9,lost,2nd,Sri Lanka,Adelaide,1/26/2006,
+Australia,won,5 wickets,9,lost,2nd,Sri Lanka,Colombo (RPS),2/25/2004,
+New Zealand,lost,5 wickets,9,won,1st,Sri Lanka,Colombo (RPS),7/25/2001,
+Pakistan,lost,5 wickets,9,won,1st,Australia,Brisbane,1/22/2010,
+Sri Lanka,lost,5 wickets,9,won,1st,Australia,Adelaide,1/26/2006,
+Sri Lanka,lost,5 wickets,9,won,1st,Australia,Colombo (RPS),2/25/2004,
+Sri Lanka,won,5 wickets,9,lost,2nd,New Zealand,Colombo (RPS),7/25/2001,
+Australia,lost,5 wickets,10,lost,1st,West Indies,Kingstown,3/18/2012,
+Australia,won,5 wickets,10,lost,2nd,New Zealand,Melbourne,2/4/2007,Stephen Fleming (NZ)
+England,lost,5 wickets,10,lost,1st,South Africa,Durban,1/17/1996,
+England,won,5 wickets,10,lost,2nd,South Africa,Bloemfontein,1/11/1996,
+India,lost,5 wickets,10,won,1st,New Zealand,Nottingham,6/12/1999,Stephen Fleming (NZ)
+India,lost,5 wickets,10,won,1st,Pakistan,Toronto,9/20/1998,
+India,lost,5 wickets,10,won,1st,Sri Lanka,Margao,12/28/1997,
+New Zealand,lost,5 wickets,10,won,1st,Australia,Melbourne,2/4/2007,Stephen Fleming (NZ)
+New Zealand,won,5 wickets,10,lost,2nd,India,Nottingham,6/12/1999,Stephen Fleming (NZ)
+New Zealand,won,5 wickets,10,won,2nd,South Africa,St George's,4/14/2007,Stephen Fleming (NZ)
+Pakistan,won,5 wickets,10,lost,2nd,India,Toronto,9/20/1998,
+South Africa,lost,5 wickets,10,lost,1st,New Zealand,St George's,4/14/2007,Stephen Fleming (NZ)
+South Africa,lost,5 wickets,10,won,1st,England,Bloemfontein,1/11/1996,
+South Africa,won,5 wickets,10,won,2nd,England,Durban,1/17/1996,
+Sri Lanka,won,5 wickets,10,lost,2nd,India,Margao,12/28/1997,
+West Indies,won,5 wickets,10,won,2nd,Australia,Kingstown,3/18/2012,
+Australia,won,5 wickets,11,lost,2nd,Pakistan,Peshawar,11/8/1998,
+England,lost,5 wickets,11,won,1st,West Indies,Kingstown,4/4/1998,
+India,won,5 wickets,11,won,2nd,West Indies,Visakhapatnam,12/2/2011,
+New Zealand,lost,5 wickets,11,lost,1st,South Africa,Centurion,11/6/2005,Stephen Fleming (NZ)
+Pakistan,lost,5 wickets,11,won,1st,Australia,Peshawar,11/8/1998,
+South Africa,won,5 wickets,11,won,2nd,New Zealand,Centurion,11/6/2005,Stephen Fleming (NZ)
+South Africa,won,5 wickets,11,won,2nd,West Indies,Lahore,11/3/1997,
+West Indies,lost,5 wickets,11,lost,1st,India,Visakhapatnam,12/2/2011,
+West Indies,lost,5 wickets,11,lost,1st,South Africa,Lahore,11/3/1997,
+West Indies,won,5 wickets,11,lost,2nd,England,Kingstown,4/4/1998,
+England,lost,5 wickets,12,lost,1st,West Indies,Gros Islet,5/1/2004,
+India,lost,5 wickets,12,lost,1st,Sri Lanka,Dhaka,1/5/2010,
+New Zealand,won,5 wickets,12,won,2nd,Sri Lanka,Christchurch,1/3/2006,Daniel Vettori (NZ)
+Sri Lanka,lost,5 wickets,12,lost,1st,New Zealand,Christchurch,1/3/2006,Daniel Vettori (NZ)
+Sri Lanka,won,5 wickets,12,won,2nd,India,Dhaka,1/5/2010,
+West Indies,won,5 wickets,12,won,2nd,England,Gros Islet,5/1/2004,
+Australia,won,5 wickets,13,lost,2nd,New Zealand,Sharjah,4/21/1998,Stephen Fleming (NZ)
+New Zealand,lost,5 wickets,13,won,1st,Australia,Sharjah,4/21/1998,Stephen Fleming (NZ)
+New Zealand,lost,5 wickets,13,won,1st,Sri Lanka,Colombo (RPS),3/29/2011,Daniel Vettori (NZ)
+New Zealand,won,5 wickets,13,lost,2nd,Pakistan,Johannesburg,10/3/2009,Daniel Vettori (NZ)
+Pakistan,lost,5 wickets,13,won,1st,New Zealand,Johannesburg,10/3/2009,Daniel Vettori (NZ)
+South Africa,won,5 wickets,13,lost,2nd,West Indies,Durban,2/1/2008,
+Sri Lanka,won,5 wickets,13,lost,2nd,New Zealand,Colombo (RPS),3/29/2011,Daniel Vettori (NZ)
+West Indies,lost,5 wickets,13,won,1st,South Africa,Durban,2/1/2008,
+Australia,lost,5 wickets,14,won,1st,India,Ahmedabad,3/24/2011,
+India,lost,5 wickets,14,lost,1st,Sri Lanka,Ahmedabad,11/6/2005,
+India,won,5 wickets,14,lost,2nd,Australia,Ahmedabad,3/24/2011,
+India,won,5 wickets,14,won,2nd,Pakistan,Lahore,2/13/2006,
+India,won,5 wickets,14,won,2nd,West Indies,Ahmedabad,11/15/2002,
+New Zealand,lost,5 wickets,14,lost,1st,Sri Lanka,Dambulla,5/13/2003,Stephen Fleming (NZ)
+Pakistan,lost,5 wickets,14,lost,1st,India,Lahore,2/13/2006,
+Sri Lanka,won,5 wickets,14,won,2nd,India,Ahmedabad,11/6/2005,
+Sri Lanka,won,5 wickets,14,won,2nd,New Zealand,Dambulla,5/13/2003,Stephen Fleming (NZ)
+West Indies,lost,5 wickets,14,lost,1st,India,Ahmedabad,11/15/2002,
+Australia,lost,5 wickets,15,won,1st,South Africa,Brisbane,1/11/1998,
+England,lost,5 wickets,15,lost,1st,India,Mohali,1/23/2013,
+India,won,5 wickets,15,won,2nd,England,Mohali,1/23/2013,
+India,won,5 wickets,15,won,2nd,South Africa,Mumbai,11/28/2005,
+South Africa,lost,5 wickets,15,lost,1st,India,Mumbai,11/28/2005,
+South Africa,won,5 wickets,15,lost,2nd,Australia,Brisbane,1/11/1998,
+England,won,5 wickets,16,lost,2nd,Pakistan,Karachi,10/24/2000,
+England,won,5 wickets,16,won,2nd,West Indies,Bridgetown,5/5/2004,
+Pakistan,lost,5 wickets,16,won,1st,England,Karachi,10/24/2000,
+West Indies,lost,5 wickets,16,lost,1st,England,Bridgetown,5/5/2004,
+England,lost,5 wickets,17,won,1st,Sri Lanka,Lord's,8/20/1998,
+India,lost,5 wickets,17,won,1st,South Africa,Sharjah,4/17/1996,
+South Africa,won,5 wickets,17,lost,2nd,India,Sharjah,4/17/1996,
+Sri Lanka,won,5 wickets,17,lost,2nd,England,Lord's,8/20/1998,
+India,won,5 wickets,18,lost,2nd,Pakistan,Guwahati,11/5/2007,
+Pakistan,lost,5 wickets,18,won,1st,India,Guwahati,11/5/2007,
+England,lost,5 wickets,19,lost,1st,New Zealand,Lord's,5/31/2013,Brendon McCullum (NZ)
+England,won,5 wickets,19,lost,2nd,Sri Lanka,Colombo (RPS),10/10/2007,
+New Zealand,won,5 wickets,19,won,2nd,England,Lord's,5/31/2013,Brendon McCullum (NZ)
+Sri Lanka,lost,5 wickets,19,won,1st,England,Colombo (RPS),10/10/2007,
+England,won,5 wickets,20,lost,2nd,Pakistan,Manchester,8/29/1996,
+Pakistan,lost,5 wickets,20,won,1st,England,Manchester,8/29/1996,
+India,won,5 wickets,21,lost,2nd,Sri Lanka,Margao,2/14/2007,
+Sri Lanka,lost,5 wickets,21,won,1st,India,Margao,2/14/2007,
+Pakistan,lost,5 wickets,22,won,1st,Sri Lanka,Dhaka,3/8/2014,
+Sri Lanka,won,5 wickets,22,lost,2nd,Pakistan,Dhaka,3/8/2014,
+India,won,5 wickets,23,won,2nd,West Indies,Kanpur,11/27/2013,
+West Indies,lost,5 wickets,23,lost,1st,India,Kanpur,11/27/2013,
+New Zealand,won,5 wickets,24,lost,2nd,South Africa,Napier,3/2/2004,Stephen Fleming (NZ)
+New Zealand,won,5 wickets,24,won,2nd,West Indies,Cardiff,7/3/2004,Stephen Fleming (NZ)
+South Africa,lost,5 wickets,24,won,1st,New Zealand,Napier,3/2/2004,Stephen Fleming (NZ)
+West Indies,lost,5 wickets,24,lost,1st,New Zealand,Cardiff,7/3/2004,Stephen Fleming (NZ)
+Australia,lost,5 wickets,25,won,1st,India,Melbourne,2/10/2008,
+India,won,5 wickets,25,lost,2nd,Australia,Melbourne,2/10/2008,
+Australia,won,5 wickets,26,won,2nd,New Zealand,Napier,3/1/2000,Stephen Fleming (NZ)
+New Zealand,lost,5 wickets,26,lost,1st,Australia,Napier,3/1/2000,Stephen Fleming (NZ)
+Australia,lost,5 wickets,28,won,1st,New Zealand,Cardiff,5/20/1999,Stephen Fleming (NZ)
+New Zealand,lost,5 wickets,28,won,1st,South Africa,Cape Town,12/2/2007,Daniel Vettori (NZ)
+New Zealand,won,5 wickets,28,lost,2nd,Australia,Cardiff,5/20/1999,Stephen Fleming (NZ)
+South Africa,won,5 wickets,28,lost,2nd,New Zealand,Cape Town,12/2/2007,Daniel Vettori (NZ)
+New Zealand,won,5 wickets,29,lost,2nd,South Africa,Christchurch,2/17/2004,Stephen Fleming (NZ)
+South Africa,lost,5 wickets,29,won,1st,New Zealand,Christchurch,2/17/2004,Stephen Fleming (NZ)
+South Africa,won,5 wickets,29,lost,2nd,Sri Lanka,Perth,1/31/2006,
+Sri Lanka,lost,5 wickets,29,won,1st,South Africa,Perth,1/31/2006,
+India,won,5 wickets,30,lost,2nd,Pakistan,Lahore,3/21/2004,
+Pakistan,lost,5 wickets,30,won,1st,India,Lahore,3/21/2004,
+Australia,won,5 wickets,31,lost,2nd,West Indies,Sydney,2/8/2013,
+West Indies,lost,5 wickets,31,won,1st,Australia,Sydney,2/8/2013,
+India,lost,5 wickets,33,won,1st,Pakistan,Hyderabad (Sind),9/28/1997,
+Pakistan,won,5 wickets,33,lost,2nd,India,Hyderabad (Sind),9/28/1997,
+Pakistan,lost,5 wickets,34,won,1st,South Africa,Karachi,2/29/1996,
+South Africa,won,5 wickets,34,lost,2nd,Pakistan,Karachi,2/29/1996,
+India,lost,5 wickets,37,lost,1st,Pakistan,Toronto,9/21/1997,
+India,lost,5 wickets,37,won,1st,Sri Lanka,Sharjah,10/20/2000,
+India,won,5 wickets,37,won,2nd,New Zealand,Auckland,1/16/1999,Dion  Nash (NZ)
+New Zealand,lost,5 wickets,37,lost,1st,India,Auckland,1/16/1999,Dion  Nash (NZ)
+Pakistan,won,5 wickets,37,won,2nd,India,Toronto,9/21/1997,
+Sri Lanka,won,5 wickets,37,lost,2nd,India,Sharjah,10/20/2000,
+Pakistan,won,5 wickets,38,lost,2nd,Sri Lanka,Sharjah,11/4/2001,
+Sri Lanka,lost,5 wickets,38,won,1st,Pakistan,Sharjah,11/4/2001,
+India,won,5 wickets,39,lost,2nd,Pakistan,Sharjah,3/23/2000,
+Pakistan,lost,5 wickets,39,won,1st,India,Sharjah,3/23/2000,
+Australia,won,5 wickets,40,lost,2nd,Pakistan,Dubai (DSC),10/10/2014,
+New Zealand,lost,5 wickets,40,lost,1st,South Africa,Auckland,3/3/2012,Brendon McCullum (NZ)
+Pakistan,lost,5 wickets,40,won,1st,Australia,Dubai (DSC),10/10/2014,
+South Africa,won,5 wickets,40,won,2nd,New Zealand,Auckland,3/3/2012,Brendon McCullum (NZ)
+England,won,5 wickets,44,lost,2nd,India,Jamshedpur,4/12/2006,
+India,lost,5 wickets,44,won,1st,England,Jamshedpur,4/12/2006,
+Pakistan,lost,5 wickets,45,lost,1st,Sri Lanka,Galle,7/5/2000,
+Sri Lanka,won,5 wickets,45,won,2nd,Pakistan,Galle,7/5/2000,
+India,lost,5 wickets,47,won,1st,Pakistan,Kanpur,4/15/2005,
+Pakistan,won,5 wickets,47,lost,2nd,India,Kanpur,4/15/2005,
+Pakistan,won,5 wickets,48,lost,2nd,Sri Lanka,Abu Dhabi,5/18/2007,
+South Africa,won,5 wickets,48,won,2nd,Sri Lanka,Bloemfontein,1/14/2001,
+Sri Lanka,lost,5 wickets,48,lost,1st,South Africa,Bloemfontein,1/14/2001,
+Sri Lanka,lost,5 wickets,48,won,1st,Pakistan,Abu Dhabi,5/18/2007,
+New Zealand,lost,5 wickets,51,lost,1st,Sri Lanka,Dhaka,10/26/1998,Stephen Fleming (NZ)
+Sri Lanka,won,5 wickets,51,won,2nd,New Zealand,Dhaka,10/26/1998,Stephen Fleming (NZ)
+New Zealand,lost,5 wickets,53,lost,1st,South Africa,Centurion,9/24/2009,Daniel Vettori (NZ)
+South Africa,won,5 wickets,53,won,2nd,New Zealand,Centurion,9/24/2009,Daniel Vettori (NZ)
+England,lost,5 wickets,55,won,1st,Sri Lanka,Dambulla,3/23/2001,
+India,lost,5 wickets,55,won,1st,Sri Lanka,Mumbai,5/17/1997,
+Sri Lanka,won,5 wickets,55,lost,2nd,England,Dambulla,3/23/2001,
+Sri Lanka,won,5 wickets,55,lost,2nd,India,Mumbai,5/17/1997,
+England,lost,5 wickets,56,won,1st,Sri Lanka,Faisalabad,3/9/1996,
+Sri Lanka,won,5 wickets,56,lost,2nd,England,Faisalabad,3/9/1996,
+India,won,5 wickets,62,lost,2nd,West Indies,Gwalior,2/21/1996,
+West Indies,lost,5 wickets,62,won,1st,India,Gwalior,2/21/1996,
+India,won,5 wickets,63,lost,2nd,Sri Lanka,Vadodara,11/12/2005,
+Sri Lanka,lost,5 wickets,63,won,1st,India,Vadodara,11/12/2005,
+England,won,5 wickets,75,won,2nd,New Zealand,Auckland,2/23/2013,Brendon McCullum (NZ)
+New Zealand,lost,5 wickets,75,lost,1st,England,Auckland,2/23/2013,Brendon McCullum (NZ)
+New Zealand,lost,5 wickets,75,won,1st,South Africa,Faisalabad,2/20/1996,Lee Germon (NZ)
+South Africa,won,5 wickets,75,lost,2nd,New Zealand,Faisalabad,2/20/1996,Lee Germon (NZ)
+India,won,5 wickets,105,won,2nd,Pakistan,Multan,2/16/2006,
+Pakistan,lost,5 wickets,105,lost,1st,India,Multan,2/16/2006,
+Australia,won,5 wickets,108,lost,2nd,India,Perth,2/1/2004,
+India,lost,5 wickets,108,won,1st,Australia,Perth,2/1/2004,
+Pakistan,won,5 wickets,117,lost,2nd,West Indies,Johannesburg,9/23/2009,
+West Indies,lost,5 wickets,117,won,1st,Pakistan,Johannesburg,9/23/2009,
+Australia,won,5 wickets,132,lost,2nd,Sri Lanka,Colombo (RPS),8/20/2011,
+Sri Lanka,lost,5 wickets,132,won,1st,Australia,Colombo (RPS),8/20/2011,
+Australia,won,5 wickets,139,lost,2nd,India,Sydney,1/14/2000,
+India,lost,5 wickets,139,won,1st,Australia,Sydney,1/14/2000,
+India,lost,5 wickets,139,won,1st,New Zealand,Christchurch,1/1/2003,Stephen Fleming (NZ)
+New Zealand,won,5 wickets,139,lost,2nd,India,Christchurch,1/1/2003,Stephen Fleming (NZ)
+South Africa,won,5 wickets,141,won,2nd,Sri Lanka,Bloemfontein,4/19/1998,
+Sri Lanka,lost,5 wickets,141,lost,1st,South Africa,Bloemfontein,4/19/1998,
+Australia,won,5 wickets,152,lost,2nd,New Zealand,Auckland,2/19/2000,Stephen Fleming (NZ)
+New Zealand,lost,5 wickets,152,won,1st,Australia,Auckland,2/19/2000,Stephen Fleming (NZ)
+Australia,won,5 wickets,153,won,2nd,South Africa,Cape Town,4/14/2000,
+South Africa,lost,5 wickets,153,lost,1st,Australia,Cape Town,4/14/2000,
+Australia,lost,50 runs,0,won,2nd,Sri Lanka,Colombo (RPS),9/7/1996,
+Australia,won,50 runs,0,lost,1st,New Zealand,Dunedin,2/23/2000,Stephen Fleming (NZ)
+Australia,won,50 runs,0,lost,1st,Sri Lanka,Galle,8/22/1999,
+Australia,won,50 runs,0,lost,1st,West Indies,Brisbane,2/14/2010,
+Australia,won,50 runs,0,lost,1st,West Indies,Johannesburg,9/26/2009,
+Australia,won,50 runs,0,won,1st,India,Adelaide,2/17/2008,
+India,lost,50 runs,0,lost,2nd,Australia,Adelaide,2/17/2008,
+India,won,50 runs,0,lost,1st,Sri Lanka,Dhaka,3/13/2012,
+New Zealand,lost,50 runs,0,won,2nd,Australia,Dunedin,2/23/2000,Stephen Fleming (NZ)
+South Africa,won,50 runs,0,won,1st,West Indies,Centurion,2/7/1999,
+Sri Lanka,lost,50 runs,0,won,2nd,Australia,Galle,8/22/1999,
+Sri Lanka,lost,50 runs,0,won,2nd,India,Dhaka,3/13/2012,
+Sri Lanka,won,50 runs,0,lost,1st,Australia,Colombo (RPS),9/7/1996,
+Sri Lanka,won,50 runs,0,won,1st,West Indies,Dambulla,8/2/2005,
+West Indies,lost,50 runs,0,lost,2nd,South Africa,Centurion,2/7/1999,
+West Indies,lost,50 runs,0,lost,2nd,Sri Lanka,Dambulla,8/2/2005,
+West Indies,lost,50 runs,0,won,2nd,Australia,Brisbane,2/14/2010,
+West Indies,lost,50 runs,0,won,2nd,Australia,Johannesburg,9/26/2009,
+Australia,lost,51 runs,0,lost,2nd,Sri Lanka,Sydney,1/22/2006,
+Australia,lost,51 runs,0,won,2nd,New Zealand,Wellington,3/13/2010,Daniel Vettori (NZ)
+Australia,won,51 runs,0,won,1st,England,Brisbane,1/30/2011,
+England,lost,51 runs,0,lost,2nd,Australia,Brisbane,1/30/2011,
+England,lost,51 runs,0,won,2nd,New Zealand,Lord's,6/28/2008,Daniel Vettori (NZ)
+India,lost,51 runs,0,lost,2nd,New Zealand,Bulawayo,8/26/2005,Stephen Fleming (NZ)
+India,lost,51 runs,0,lost,2nd,Sri Lanka,Brisbane,2/21/2012,
+India,lost,51 runs,0,won,2nd,Pakistan,Toronto,9/13/1998,
+India,won,51 runs,0,lost,1st,Sri Lanka,Pune,3/30/1999,
+India,won,51 runs,0,won,1st,Pakistan,Abu Dhabi,4/19/2006,
+New Zealand,lost,51 runs,0,lost,2nd,Pakistan,Faisalabad,12/3/2003,
+New Zealand,lost,51 runs,0,lost,2nd,Pakistan,Sharjah,4/11/2002,
+New Zealand,won,51 runs,0,lost,1st,Australia,Wellington,3/13/2010,Daniel Vettori (NZ)
+New Zealand,won,51 runs,0,lost,1st,England,Lord's,6/28/2008,Daniel Vettori (NZ)
+New Zealand,won,51 runs,0,lost,1st,Pakistan,Mohali,10/25/2006,Stephen Fleming (NZ)
+New Zealand,won,51 runs,0,won,1st,India,Bulawayo,8/26/2005,Stephen Fleming (NZ)
+Pakistan,lost,51 runs,0,lost,2nd,India,Abu Dhabi,4/19/2006,
+Pakistan,lost,51 runs,0,lost,2nd,Sri Lanka,Sharjah,4/7/1997,
+Pakistan,lost,51 runs,0,won,2nd,New Zealand,Mohali,10/25/2006,Stephen Fleming (NZ)
+Pakistan,won,51 runs,0,lost,1st,India,Toronto,9/13/1998,
+Pakistan,won,51 runs,0,won,1st,New Zealand,Faisalabad,12/3/2003,
+Pakistan,won,51 runs,0,won,1st,New Zealand,Sharjah,4/11/2002,
+Pakistan,won,51 runs,0,won,1st,West Indies,Sharjah,2/15/2002,
+Sri Lanka,lost,51 runs,0,won,2nd,India,Pune,3/30/1999,
+Sri Lanka,won,51 runs,0,won,1st,Australia,Sydney,1/22/2006,
+Sri Lanka,won,51 runs,0,won,1st,India,Brisbane,2/21/2012,
+Sri Lanka,won,51 runs,0,won,1st,Pakistan,Sharjah,4/7/1997,
+West Indies,lost,51 runs,0,lost,2nd,Pakistan,Sharjah,2/15/2002,
+India,lost,52 runs,0,lost,2nd,Pakistan,Toronto,9/23/1996,
+New Zealand,lost,52 runs,0,lost,2nd,Sri Lanka,Hyderabad (Deccan),5/20/1997,Stephen Fleming (NZ)
+Pakistan,lost,52 runs,0,lost,2nd,South Africa,Durban,4/3/1998,
+Pakistan,won,52 runs,0,won,1st,India,Toronto,9/23/1996,
+South Africa,won,52 runs,0,won,1st,Pakistan,Durban,4/3/1998,
+Sri Lanka,won,52 runs,0,won,1st,New Zealand,Hyderabad (Deccan),5/20/1997,Stephen Fleming (NZ)
+Australia,won,53 runs,0,won,1st,Sri Lanka,Bridgetown,4/28/2007,
+India,won,53 runs,0,won,1st,New Zealand,Napier,3/3/2009,Daniel Vettori (NZ)
+New Zealand,lost,53 runs,0,lost,2nd,India,Napier,3/3/2009,Daniel Vettori (NZ)
+South Africa,won,53 runs,0,lost,1st,West Indies,Port of Spain,5/12/2001,
+Sri Lanka,lost,53 runs,0,lost,2nd,Australia,Bridgetown,4/28/2007,
+West Indies,lost,53 runs,0,won,2nd,South Africa,Port of Spain,5/12/2001,
+Australia,won,54 runs,0,lost,1st,West Indies,Perth,2/3/2013,
+England,lost,54 runs,0,lost,2nd,India,Indore,11/17/2008,
+India,lost,54 runs,0,lost,2nd,Pakistan,Centurion,9/26/2009,
+India,won,54 runs,0,won,1st,England,Indore,11/17/2008,
+Pakistan,lost,54 runs,0,lost,2nd,South Africa,Tangier,8/12/2002,
+Pakistan,lost,54 runs,0,won,2nd,West Indies,Kingston,3/13/2007,
+Pakistan,won,54 runs,0,won,1st,India,Centurion,9/26/2009,
+South Africa,won,54 runs,0,won,1st,Pakistan,Tangier,8/12/2002,
+West Indies,lost,54 runs,0,won,2nd,Australia,Perth,2/3/2013,
+West Indies,won,54 runs,0,lost,1st,Pakistan,Kingston,3/13/2007,
+India,won,55 runs,0,won,1st,Pakistan,Toronto,9/18/1996,
+New Zealand,lost,55 runs,0,won,2nd,West Indies,Kingston,7/7/2012,
+Pakistan,lost,55 runs,0,lost,2nd,India,Toronto,9/18/1996,
+South Africa,lost,55 runs,0,won,2nd,Sri Lanka,Centurion,9/22/2009,
+South Africa,won,55 runs,0,won,1st,West Indies,Durban,1/27/1999,
+Sri Lanka,won,55 runs,0,lost,1st,South Africa,Centurion,9/22/2009,
+Sri Lanka,won,55 runs,0,lost,1st,West Indies,Bridgetown,6/7/2003,
+West Indies,lost,55 runs,0,lost,2nd,South Africa,Durban,1/27/1999,
+West Indies,lost,55 runs,0,won,2nd,Sri Lanka,Bridgetown,6/7/2003,
+West Indies,won,55 runs,0,lost,1st,New Zealand,Kingston,7/7/2012,
+India,won,56 runs,0,won,1st,West Indies,Port of Spain,6/2/2002,
+South Africa,won,56 runs,0,won,1st,Sri Lanka,Pallekele,7/26/2013,
+Sri Lanka,lost,56 runs,0,lost,2nd,South Africa,Pallekele,7/26/2013,
+West Indies,lost,56 runs,0,lost,2nd,India,Port of Spain,6/2/2002,
+Australia,lost,57 runs,0,won,2nd,England,Perth,1/24/2014,
+Australia,lost,57 runs,0,won,2nd,India,Bangalore,11/2/2013,
+Australia,won,57 runs,0,lost,1st,England,Chester-le-Street,6/23/2005,
+Australia,won,57 runs,0,won,1st,England,Perth,2/6/2011,
+Australia,won,57 runs,0,won,1st,South Africa,Sydney,2/5/2006,
+England,lost,57 runs,0,lost,2nd,Australia,Perth,2/6/2011,
+England,lost,57 runs,0,lost,2nd,West Indies,Port of Spain,4/8/1998,
+England,lost,57 runs,0,won,2nd,Australia,Chester-le-Street,6/23/2005,
+England,won,57 runs,0,lost,1st,Australia,Perth,1/24/2014,
+India,won,57 runs,0,lost,1st,Australia,Bangalore,11/2/2013,
+New Zealand,won,57 runs,0,lost,1st,Pakistan,Auckland,2/5/2011,Ross Taylor (NZ)
+Pakistan,lost,57 runs,0,lost,2nd,South Africa,Dubai (DSC),11/8/2010,
+Pakistan,lost,57 runs,0,won,2nd,New Zealand,Auckland,2/5/2011,Ross Taylor (NZ)
+South Africa,lost,57 runs,0,lost,2nd,Australia,Sydney,2/5/2006,
+South Africa,lost,57 runs,0,won,2nd,Sri Lanka,Nottingham,8/14/1998,
+South Africa,won,57 runs,0,won,1st,Pakistan,Dubai (DSC),11/8/2010,
+South Africa,won,57 runs,0,won,1st,Sri Lanka,Johannesburg,4/5/1998,
+Sri Lanka,lost,57 runs,0,lost,2nd,South Africa,Johannesburg,4/5/1998,
+Sri Lanka,won,57 runs,0,lost,1st,South Africa,Nottingham,8/14/1998,
+West Indies,won,57 runs,0,won,1st,England,Port of Spain,4/8/1998,
+Australia,won,58 runs,0,won,1st,India,Sharjah,4/19/1998,
+England,lost,58 runs,0,lost,2nd,New Zealand,Perth,1/30/2007,Stephen Fleming (NZ)
+England,won,58 runs,0,lost,1st,West Indies,Birmingham,5/26/2009,
+India,lost,58 runs,0,lost,2nd,Australia,Sharjah,4/19/1998,
+India,won,58 runs,0,lost,1st,New Zealand,Christchurch,3/8/2009,Brendon McCullum (NZ)
+India,won,58 runs,0,won,1st,Pakistan,Visakhapatnam,4/5/2005,
+New Zealand,lost,58 runs,0,won,2nd,India,Christchurch,3/8/2009,Brendon McCullum (NZ)
+New Zealand,won,58 runs,0,won,1st,England,Perth,1/30/2007,Stephen Fleming (NZ)
+New Zealand,won,58 runs,0,won,1st,West Indies,Nelson,1/4/2014,Brendon McCullum (NZ)
+Pakistan,lost,58 runs,0,lost,2nd,India,Visakhapatnam,4/5/2005,
+Pakistan,lost,58 runs,0,won,2nd,West Indies,Adelaide,1/28/2005,
+West Indies,lost,58 runs,0,lost,2nd,New Zealand,Nelson,1/4/2014,Brendon McCullum (NZ)
+West Indies,lost,58 runs,0,won,2nd,England,Birmingham,5/26/2009,
+West Indies,won,58 runs,0,lost,1st,Pakistan,Adelaide,1/28/2005,
+Australia,won,59 runs,0,won,1st,England,Southampton,9/3/2015,
+Australia,won,59 runs,0,won,1st,South Africa,Melbourne (Docklands),1/20/2006,
+England,lost,59 runs,0,lost,2nd,Australia,Southampton,9/3/2015,
+India,lost,59 runs,0,lost,2nd,Pakistan,Colombo (RPS),7/25/2004,
+India,won,59 runs,0,lost,1st,West Indies,Dharamsala,10/17/2014,
+Pakistan,won,59 runs,0,lost,1st,West Indies,Kingstown,5/18/2005,
+Pakistan,won,59 runs,0,won,1st,India,Colombo (RPS),7/25/2004,
+South Africa,lost,59 runs,0,lost,2nd,Australia,Melbourne (Docklands),1/20/2006,
+West Indies,lost,59 runs,0,won,2nd,India,Dharamsala,10/17/2014,
+West Indies,lost,59 runs,0,won,2nd,Pakistan,Kingstown,5/18/2005,
+Australia,lost,6 runs,0,lost,2nd,South Africa,Melbourne,1/23/1998,
+England,lost,6 runs,0,lost,2nd,South Africa,Cape Town,1/9/1996,
+England,won,6 runs,0,won,1st,Pakistan,Rawalpindi,12/21/2005,
+England,won,6 runs,0,won,1st,South Africa,Chennai,3/6/2011,
+India,lost,6 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),7/22/2001,
+India,won,6 runs,0,won,1st,Sri Lanka,Colombo (RPS),7/7/1998,
+Pakistan,lost,6 runs,0,lost,2nd,England,Rawalpindi,12/21/2005,
+South Africa,lost,6 runs,0,lost,2nd,England,Chennai,3/6/2011,
+South Africa,won,6 runs,0,won,1st,Australia,Melbourne,1/23/1998,
+South Africa,won,6 runs,0,won,1st,England,Cape Town,1/9/1996,
+Sri Lanka,lost,6 runs,0,lost,2nd,India,Colombo (RPS),7/7/1998,
+Sri Lanka,won,6 runs,0,won,1st,India,Colombo (RPS),7/22/2001,
+Sri Lanka,won,6 runs,0,won,1st,West Indies,Cape Town,2/28/2003,
+West Indies,lost,6 runs,0,lost,2nd,Sri Lanka,Cape Town,2/28/2003,
+India,won,6 wickets,1,won,2nd,West Indies,Gros Islet,7/3/2009,
+West Indies,lost,6 wickets,1,lost,1st,India,Gros Islet,7/3/2009,
+England,lost,6 wickets,2,won,1st,Sri Lanka,Colombo (RPS),12/7/2014,
+Sri Lanka,won,6 wickets,2,lost,2nd,England,Colombo (RPS),12/7/2014,
+Australia,lost,6 wickets,3,lost,1st,India,Nagpur,10/30/2013,
+India,won,6 wickets,3,won,2nd,Australia,Nagpur,10/30/2013,
+India,lost,6 wickets,4,won,1st,South Africa,East London,2/4/1997,
+India,won,6 wickets,4,won,2nd,South Africa,Belfast,7/1/2007,
+Pakistan,lost,6 wickets,4,won,1st,Sri Lanka,Colombo (RPS),7/9/2000,
+South Africa,lost,6 wickets,4,lost,1st,India,Belfast,7/1/2007,
+South Africa,won,6 wickets,4,lost,2nd,India,East London,2/4/1997,
+Sri Lanka,won,6 wickets,4,lost,2nd,Pakistan,Colombo (RPS),7/9/2000,
+Australia,won,6 wickets,5,lost,2nd,England,Melbourne,1/16/2011,
+England,lost,6 wickets,5,won,1st,Australia,Melbourne,1/16/2011,
+India,won,6 wickets,5,won,2nd,South Africa,Belfast,6/29/2007,
+New Zealand,lost,6 wickets,5,lost,1st,West Indies,Gros Islet,6/8/2002,Stephen Fleming (NZ)
+South Africa,lost,6 wickets,5,lost,1st,India,Belfast,6/29/2007,
+West Indies,won,6 wickets,5,won,2nd,New Zealand,Gros Islet,6/8/2002,Stephen Fleming (NZ)
+Australia,lost,6 wickets,6,lost,1st,England,Lord's,5/25/1997,
+England,won,6 wickets,6,won,2nd,Australia,Lord's,5/25/1997,
+India,lost,6 wickets,6,won,1st,Pakistan,Kolkata,11/13/2004,
+New Zealand,won,6 wickets,6,won,2nd,South Africa,Dunedin,2/25/2004,Stephen Fleming (NZ)
+Pakistan,won,6 wickets,6,lost,2nd,India,Kolkata,11/13/2004,
+Pakistan,won,6 wickets,6,won,2nd,West Indies,Gros Islet,7/21/2013,
+South Africa,lost,6 wickets,6,lost,1st,New Zealand,Dunedin,2/25/2004,Stephen Fleming (NZ)
+West Indies,lost,6 wickets,6,lost,1st,Pakistan,Gros Islet,7/21/2013,
+Australia,lost,6 wickets,7,lost,1st,New Zealand,Melbourne,2/6/2009,Daniel Vettori (NZ)
+Australia,won,6 wickets,7,lost,2nd,Pakistan,Lahore,11/10/1998,
+England,lost,6 wickets,7,won,1st,India,Lord's,6/29/2002,
+India,won,6 wickets,7,lost,2nd,England,Lord's,6/29/2002,
+New Zealand,won,6 wickets,7,won,2nd,Australia,Melbourne,2/6/2009,Daniel Vettori (NZ)
+Pakistan,lost,6 wickets,7,won,1st,Australia,Lahore,11/10/1998,
+Pakistan,won,6 wickets,7,won,2nd,Sri Lanka,Lahore,10/14/2004,
+Sri Lanka,lost,6 wickets,7,lost,1st,Pakistan,Lahore,10/14/2004,
+India,lost,6 wickets,8,lost,1st,Sri Lanka,Delhi,3/2/1996,
+Sri Lanka,won,6 wickets,8,won,2nd,India,Delhi,3/2/1996,
+Australia,lost,6 wickets,9,lost,1st,India,Sharjah,4/24/1998,
+Australia,won,6 wickets,9,lost,2nd,England,Southampton,9/9/2009,
+England,lost,6 wickets,9,won,1st,Australia,Southampton,9/9/2009,
+India,lost,6 wickets,9,won,1st,Pakistan,Abu Dhabi,4/18/2006,
+India,won,6 wickets,9,won,2nd,Australia,Sharjah,4/24/1998,
+New Zealand,lost,6 wickets,9,lost,1st,South Africa,Durban,11/1/2000,Stephen Fleming (NZ)
+Pakistan,won,6 wickets,9,lost,2nd,India,Abu Dhabi,4/18/2006,
+South Africa,won,6 wickets,9,won,2nd,New Zealand,Durban,11/1/2000,Stephen Fleming (NZ)
+Australia,lost,6 wickets,10,lost,1st,England,The Oval,5/24/1997,
+Australia,lost,6 wickets,10,won,1st,India,Delhi,10/31/2009,
+Australia,won,6 wickets,10,lost,2nd,New Zealand,Adelaide,2/10/2009,Daniel Vettori (NZ)
+England,lost,6 wickets,10,won,1st,Sri Lanka,Birmingham,6/3/2014,
+England,lost,6 wickets,10,won,1st,Sri Lanka,Lord's,7/3/2011,
+England,won,6 wickets,10,won,2nd,Australia,The Oval,5/24/1997,
+England,won,6 wickets,10,won,2nd,India,Cardiff,9/16/2011,
+India,lost,6 wickets,10,lost,1st,England,Cardiff,9/16/2011,
+India,lost,6 wickets,10,lost,1st,South Africa,Johannesburg,10/5/2001,
+India,lost,6 wickets,10,lost,1st,Sri Lanka,Harare,6/5/2010,
+India,won,6 wickets,10,lost,2nd,Australia,Delhi,10/31/2009,
+India,won,6 wickets,10,lost,2nd,Sri Lanka,Mumbai,4/2/2011,
+New Zealand,lost,6 wickets,10,won,1st,Australia,Adelaide,2/10/2009,Daniel Vettori (NZ)
+South Africa,won,6 wickets,10,won,2nd,India,Johannesburg,10/5/2001,
+Sri Lanka,lost,6 wickets,10,won,1st,India,Mumbai,4/2/2011,
+Sri Lanka,won,6 wickets,10,lost,2nd,England,Birmingham,6/3/2014,
+Sri Lanka,won,6 wickets,10,lost,2nd,England,Lord's,7/3/2011,
+Sri Lanka,won,6 wickets,10,won,2nd,India,Harare,6/5/2010,
+India,lost,6 wickets,11,lost,1st,Pakistan,Chennai,12/30/2012,
+India,lost,6 wickets,11,won,1st,New Zealand,Harare,9/6/2005,Stephen Fleming (NZ)
+India,won,6 wickets,11,lost,2nd,Pakistan,Sharjah,4/13/1999,
+India,won,6 wickets,11,won,2nd,Sri Lanka,Dambulla,1/28/2009,
+India,won,6 wickets,11,won,2nd,West Indies,Harare,7/4/2001,
+New Zealand,lost,6 wickets,11,lost,1st,South Africa,Mount Maunganui,10/21/2014,Brendon McCullum (NZ)
+New Zealand,won,6 wickets,11,lost,2nd,India,Harare,9/6/2005,Stephen Fleming (NZ)
+Pakistan,lost,6 wickets,11,lost,1st,West Indies,Brisbane,1/3/1997,
+Pakistan,lost,6 wickets,11,won,1st,India,Sharjah,4/13/1999,
+Pakistan,won,6 wickets,11,lost,2nd,South Africa,Faisalabad,10/23/2007,
+Pakistan,won,6 wickets,11,won,2nd,India,Chennai,12/30/2012,
+South Africa,lost,6 wickets,11,won,1st,Pakistan,Faisalabad,10/23/2007,
+South Africa,won,6 wickets,11,won,2nd,New Zealand,Mount Maunganui,10/21/2014,Brendon McCullum (NZ)
+Sri Lanka,lost,6 wickets,11,lost,1st,India,Dambulla,1/28/2009,
+West Indies,lost,6 wickets,11,lost,1st,India,Harare,7/4/2001,
+West Indies,won,6 wickets,11,won,2nd,Pakistan,Brisbane,1/3/1997,
+Australia,lost,6 wickets,12,lost,1st,South Africa,Durban,4/12/2000,
+South Africa,won,6 wickets,12,won,2nd,Australia,Durban,4/12/2000,
+South Africa,won,6 wickets,12,won,2nd,West Indies,Centurion,1/20/2008,
+West Indies,lost,6 wickets,12,lost,1st,South Africa,Centurion,1/20/2008,
+Australia,won,6 wickets,13,lost,2nd,New Zealand,Chennai,3/11/1996,Lee Germon (NZ)
+Australia,won,6 wickets,13,won,2nd,Pakistan,Melbourne,1/16/2000,
+India,won,6 wickets,13,lost,2nd,Pakistan,Dhaka,3/18/2012,
+New Zealand,lost,6 wickets,13,won,1st,Australia,Chennai,3/11/1996,Lee Germon (NZ)
+Pakistan,lost,6 wickets,13,lost,1st,Australia,Melbourne,1/16/2000,
+Pakistan,lost,6 wickets,13,won,1st,India,Dhaka,3/18/2012,
+New Zealand,lost,6 wickets,14,won,1st,Sri Lanka,Hamilton,1/15/2015,Brendon McCullum (NZ)
+Sri Lanka,won,6 wickets,14,lost,2nd,New Zealand,Hamilton,1/15/2015,Brendon McCullum (NZ)
+England,won,6 wickets,15,won,2nd,India,Leeds,5/25/1996,
+India,lost,6 wickets,15,lost,1st,England,Leeds,5/25/1996,
+India,won,6 wickets,15,lost,2nd,New Zealand,Harare,9/2/2005,Stephen Fleming (NZ)
+New Zealand,lost,6 wickets,15,won,1st,India,Harare,9/2/2005,Stephen Fleming (NZ)
+Australia,won,6 wickets,16,won,2nd,New Zealand,Hamilton,3/9/2010,Daniel Vettori (NZ)
+England,lost,6 wickets,16,lost,1st,New Zealand,Bristol,7/4/2004,Stephen Fleming (NZ)
+New Zealand,lost,6 wickets,16,lost,1st,Australia,Hamilton,3/9/2010,Daniel Vettori (NZ)
+New Zealand,won,6 wickets,16,won,2nd,England,Bristol,7/4/2004,Stephen Fleming (NZ)
+Australia,won,6 wickets,17,won,2nd,New Zealand,Auckland,3/11/2010,Daniel Vettori (NZ)
+India,won,6 wickets,17,lost,2nd,South Africa,Jamshedpur,3/12/2000,
+New Zealand,lost,6 wickets,17,lost,1st,Australia,Auckland,3/11/2010,Daniel Vettori (NZ)
+South Africa,lost,6 wickets,17,won,1st,India,Jamshedpur,3/12/2000,
+Australia,lost,6 wickets,18,lost,1st,South Africa,East London,3/29/1997,
+England,won,6 wickets,18,won,2nd,New Zealand,Auckland,2/15/2008,Daniel Vettori (NZ)
+India,lost,6 wickets,18,won,1st,West Indies,Dhaka,10/31/1998,
+New Zealand,lost,6 wickets,18,lost,1st,England,Auckland,2/15/2008,Daniel Vettori (NZ)
+New Zealand,lost,6 wickets,18,lost,1st,Pakistan,Queenstown,1/7/2004,Stephen Fleming (NZ)
+Pakistan,won,6 wickets,18,won,2nd,New Zealand,Queenstown,1/7/2004,Stephen Fleming (NZ)
+Pakistan,won,6 wickets,18,won,2nd,West Indies,Brisbane,1/19/2005,
+South Africa,won,6 wickets,18,won,2nd,Australia,East London,3/29/1997,
+West Indies,lost,6 wickets,18,lost,1st,Pakistan,Brisbane,1/19/2005,
+West Indies,won,6 wickets,18,lost,2nd,India,Dhaka,10/31/1998,
+India,won,6 wickets,19,lost,2nd,Sri Lanka,Karachi,7/3/2008,
+South Africa,won,6 wickets,19,won,2nd,West Indies,Port of Spain,5/14/2005,
+Sri Lanka,lost,6 wickets,19,won,1st,India,Karachi,7/3/2008,
+West Indies,lost,6 wickets,19,lost,1st,South Africa,Port of Spain,5/14/2005,
+England,lost,6 wickets,20,won,1st,South Africa,Dhaka,10/25/1998,
+England,won,6 wickets,20,won,2nd,South Africa,Lord's,9/2/2012,
+New Zealand,lost,6 wickets,20,won,1st,South Africa,Benoni,10/22/2000,Stephen Fleming (NZ)
+South Africa,lost,6 wickets,20,lost,1st,England,Lord's,9/2/2012,
+South Africa,lost,6 wickets,20,won,1st,Sri Lanka,Port Elizabeth,4/13/1998,
+South Africa,won,6 wickets,20,lost,2nd,England,Dhaka,10/25/1998,
+South Africa,won,6 wickets,20,lost,2nd,New Zealand,Benoni,10/22/2000,Stephen Fleming (NZ)
+Sri Lanka,won,6 wickets,20,lost,2nd,South Africa,Port Elizabeth,4/13/1998,
+Australia,lost,6 wickets,21,lost,1st,England,Birmingham,9/21/2004,
+Australia,lost,6 wickets,21,won,1st,South Africa,Centurion,2/26/2006,
+England,won,6 wickets,21,won,2nd,Australia,Birmingham,9/21/2004,
+India,won,6 wickets,21,lost,2nd,Pakistan,Gwalior,11/15/2007,
+Pakistan,lost,6 wickets,21,lost,1st,Sri Lanka,Dambulla,8/3/2009,
+Pakistan,lost,6 wickets,21,won,1st,India,Gwalior,11/15/2007,
+South Africa,won,6 wickets,21,lost,2nd,Australia,Centurion,2/26/2006,
+Sri Lanka,won,6 wickets,21,won,2nd,Pakistan,Dambulla,8/3/2009,
+India,won,6 wickets,23,lost,2nd,Sri Lanka,Jaipur,10/31/2005,
+Sri Lanka,lost,6 wickets,23,won,1st,India,Jaipur,10/31/2005,
+Australia,lost,6 wickets,25,won,1st,India,Sydney,3/2/2008,
+England,won,6 wickets,25,lost,2nd,South Africa,The Oval,6/28/2003,
+India,won,6 wickets,25,lost,2nd,Australia,Sydney,3/2/2008,
+South Africa,lost,6 wickets,25,won,1st,England,The Oval,6/28/2003,
+Australia,lost,6 wickets,26,won,1st,England,The Oval,7/1/2012,
+Australia,won,6 wickets,26,lost,2nd,England,Melbourne,1/12/2014,
+Australia,won,6 wickets,26,lost,2nd,India,Mohali,10/29/2006,
+England,lost,6 wickets,26,won,1st,Australia,Melbourne,1/12/2014,
+England,won,6 wickets,26,lost,2nd,Australia,The Oval,7/1/2012,
+India,lost,6 wickets,26,won,1st,Australia,Mohali,10/29/2006,
+India,won,6 wickets,26,lost,2nd,Pakistan,Centurion,3/1/2003,
+Pakistan,lost,6 wickets,26,won,1st,India,Centurion,3/1/2003,
+Australia,won,6 wickets,28,lost,2nd,New Zealand,Centurion,10/5/2009,Brendon McCullum (NZ)
+New Zealand,lost,6 wickets,28,won,1st,Australia,Centurion,10/5/2009,Brendon McCullum (NZ)
+New Zealand,lost,6 wickets,28,won,1st,South Africa,Wellington,2/25/2012,Brendon McCullum (NZ)
+Pakistan,won,6 wickets,28,lost,2nd,South Africa,Centurion,3/15/2013,
+Pakistan,won,6 wickets,28,won,2nd,Sri Lanka,Dambulla,7/11/2015,
+South Africa,lost,6 wickets,28,won,1st,Pakistan,Centurion,3/15/2013,
+South Africa,won,6 wickets,28,lost,2nd,New Zealand,Wellington,2/25/2012,Brendon McCullum (NZ)
+Sri Lanka,lost,6 wickets,28,lost,1st,Pakistan,Dambulla,7/11/2015,
+Australia,won,6 wickets,29,lost,2nd,Pakistan,Dubai (DSC),4/24/2009,
+India,lost,6 wickets,29,won,1st,South Africa,Port Elizabeth,2/2/1997,
+New Zealand,lost,6 wickets,29,won,1st,Sri Lanka,St George's,4/12/2007,Stephen Fleming (NZ)
+Pakistan,lost,6 wickets,29,won,1st,Australia,Dubai (DSC),4/24/2009,
+South Africa,won,6 wickets,29,lost,2nd,India,Port Elizabeth,2/2/1997,
+South Africa,won,6 wickets,29,lost,2nd,Sri Lanka,Bloemfontein,12/6/2002,
+Sri Lanka,lost,6 wickets,29,won,1st,South Africa,Bloemfontein,12/6/2002,
+Sri Lanka,won,6 wickets,29,lost,2nd,New Zealand,St George's,4/12/2007,Stephen Fleming (NZ)
+England,won,6 wickets,30,won,2nd,Sri Lanka,Johannesburg,9/25/2009,
+New Zealand,lost,6 wickets,30,lost,1st,Pakistan,Auckland,2/17/2001,Stephen Fleming (NZ)
+Pakistan,won,6 wickets,30,won,2nd,New Zealand,Auckland,2/17/2001,Stephen Fleming (NZ)
+Sri Lanka,lost,6 wickets,30,lost,1st,England,Johannesburg,9/25/2009,
+Sri Lanka,lost,6 wickets,31,lost,1st,West Indies,Kingstown,6/11/2003,
+West Indies,won,6 wickets,31,won,2nd,Sri Lanka,Kingstown,6/11/2003,
+India,lost,6 wickets,32,lost,1st,Sri Lanka,Colombo (RPS),7/18/1997,
+Sri Lanka,won,6 wickets,32,won,2nd,India,Colombo (RPS),7/18/1997,
+Australia,lost,6 wickets,33,won,1st,India,Kanpur,4/7/1998,
+India,won,6 wickets,33,lost,2nd,Australia,Kanpur,4/7/1998,
+India,won,6 wickets,33,lost,2nd,Sri Lanka,Ahmedabad,11/6/2014,
+Sri Lanka,lost,6 wickets,33,won,1st,India,Ahmedabad,11/6/2014,
+South Africa,lost,6 wickets,34,won,1st,West Indies,Kingstown,5/16/2001,
+West Indies,won,6 wickets,34,lost,2nd,South Africa,Kingstown,5/16/2001,
+India,won,6 wickets,35,lost,2nd,Sri Lanka,Hyderabad (Deccan),11/9/2014,
+Sri Lanka,lost,6 wickets,35,won,1st,India,Hyderabad (Deccan),11/9/2014,
+India,lost,6 wickets,36,lost,1st,West Indies,Port of Spain,5/26/2006,
+Pakistan,lost,6 wickets,36,won,1st,South Africa,Benoni,3/24/2013,
+South Africa,lost,6 wickets,36,won,1st,West Indies,Jaipur,11/2/2006,
+South Africa,won,6 wickets,36,lost,2nd,Pakistan,Benoni,3/24/2013,
+West Indies,won,6 wickets,36,lost,2nd,South Africa,Jaipur,11/2/2006,
+West Indies,won,6 wickets,36,won,2nd,India,Port of Spain,5/26/2006,
+India,won,6 wickets,37,won,2nd,West Indies,Bulawayo,6/30/2001,
+West Indies,lost,6 wickets,37,lost,1st,India,Bulawayo,6/30/2001,
+England,lost,6 wickets,38,lost,1st,India,Cuttack,11/26/2008,
+England,lost,6 wickets,38,won,1st,Pakistan,Abu Dhabi,11/11/2015,
+India,won,6 wickets,38,won,2nd,England,Cuttack,11/26/2008,
+India,won,6 wickets,38,won,2nd,Pakistan,Toronto,9/12/1998,
+Pakistan,lost,6 wickets,38,lost,1st,India,Toronto,9/12/1998,
+Pakistan,lost,6 wickets,38,lost,1st,Sri Lanka,Dambulla,8/1/2009,
+Pakistan,won,6 wickets,38,lost,2nd,England,Abu Dhabi,11/11/2015,
+Sri Lanka,won,6 wickets,38,won,2nd,Pakistan,Dambulla,8/1/2009,
+England,lost,6 wickets,39,lost,1st,Pakistan,Rawalpindi,10/30/2000,
+England,won,6 wickets,39,lost,2nd,New Zealand,Auckland,2/23/1997,Lee Germon (NZ)
+New Zealand,lost,6 wickets,39,won,1st,England,Auckland,2/23/1997,Lee Germon (NZ)
+Pakistan,won,6 wickets,39,won,2nd,England,Rawalpindi,10/30/2000,
+England,lost,6 wickets,42,lost,1st,India,Nottingham,8/30/2014,
+India,won,6 wickets,42,won,2nd,England,Nottingham,8/30/2014,
+Australia,won,6 wickets,44,lost,2nd,Pakistan,Melbourne,2/2/2000,
+India,lost,6 wickets,44,won,1st,South Africa,Sharjah,3/27/2000,
+Pakistan,lost,6 wickets,44,won,1st,Australia,Melbourne,2/2/2000,
+South Africa,won,6 wickets,44,lost,2nd,India,Sharjah,3/27/2000,
+India,won,6 wickets,46,lost,2nd,Sri Lanka,Colombo (RPS),7/31/2012,
+Sri Lanka,lost,6 wickets,46,won,1st,India,Colombo (RPS),7/31/2012,
+India,lost,6 wickets,47,lost,1st,South Africa,Durban,10/26/2001,
+India,won,6 wickets,47,lost,2nd,Pakistan,Karachi,6/26/2008,
+New Zealand,lost,6 wickets,47,won,1st,South Africa,Sydney,2/8/2002,Stephen Fleming (NZ)
+Pakistan,lost,6 wickets,47,won,1st,India,Karachi,6/26/2008,
+Pakistan,won,6 wickets,47,lost,2nd,Sri Lanka,Pallekele,6/7/2012,
+South Africa,lost,6 wickets,47,won,1st,Sri Lanka,Tangier,8/19/2002,
+South Africa,won,6 wickets,47,lost,2nd,New Zealand,Sydney,2/8/2002,Stephen Fleming (NZ)
+South Africa,won,6 wickets,47,won,2nd,India,Durban,10/26/2001,
+Sri Lanka,lost,6 wickets,47,won,1st,Pakistan,Pallekele,6/7/2012,
+Sri Lanka,won,6 wickets,47,lost,2nd,South Africa,Tangier,8/19/2002,
+Australia,won,6 wickets,49,lost,2nd,India,Guwahati,11/8/2009,
+India,lost,6 wickets,49,won,1st,Australia,Guwahati,11/8/2009,
+Australia,won,6 wickets,54,lost,2nd,Sri Lanka,Perth,1/29/2006,
+England,lost,6 wickets,54,lost,1st,New Zealand,Gros Islet,3/16/2007,Stephen Fleming (NZ)
+England,won,6 wickets,54,lost,2nd,Pakistan,Sharjah,11/17/2015,
+New Zealand,won,6 wickets,54,won,2nd,England,Gros Islet,3/16/2007,Stephen Fleming (NZ)
+Pakistan,lost,6 wickets,54,won,1st,England,Sharjah,11/17/2015,
+Sri Lanka,lost,6 wickets,54,won,1st,Australia,Perth,1/29/2006,
+Australia,lost,6 wickets,55,lost,1st,South Africa,Harare,9/6/2014,
+South Africa,won,6 wickets,55,won,2nd,Australia,Harare,9/6/2014,
+Australia,won,6 wickets,56,won,2nd,West Indies,Manchester,5/30/1999,
+West Indies,lost,6 wickets,56,lost,1st,Australia,Manchester,5/30/1999,
+India,won,6 wickets,57,lost,2nd,New Zealand,Colombo (RPS),9/11/2009,Daniel Vettori (NZ)
+New Zealand,lost,6 wickets,57,won,1st,India,Colombo (RPS),9/11/2009,Daniel Vettori (NZ)
+Australia,lost,6 wickets,59,lost,1st,England,Leeds,5/22/1997,
+England,lost,6 wickets,59,won,1st,India,Mumbai,10/23/2011,
+England,won,6 wickets,59,won,2nd,Australia,Leeds,5/22/1997,
+India,won,6 wickets,59,lost,2nd,England,Mumbai,10/23/2011,
+Pakistan,won,6 wickets,61,lost,2nd,Sri Lanka,Dhaka,3/15/2012,
+Sri Lanka,lost,6 wickets,61,won,1st,Pakistan,Dhaka,3/15/2012,
+Australia,won,6 wickets,67,lost,2nd,New Zealand,Melbourne,12/17/1997,Stephen Fleming (NZ)
+New Zealand,lost,6 wickets,67,won,1st,Australia,Melbourne,12/17/1997,Stephen Fleming (NZ)
+Pakistan,lost,6 wickets,67,won,1st,South Africa,Rawalpindi,10/10/2003,
+South Africa,won,6 wickets,67,lost,2nd,Pakistan,Rawalpindi,10/10/2003,
+New Zealand,lost,6 wickets,70,lost,1st,South Africa,Napier,2/29/2012,Brendon McCullum (NZ)
+South Africa,won,6 wickets,70,won,2nd,New Zealand,Napier,2/29/2012,Brendon McCullum (NZ)
+Sri Lanka,lost,6 wickets,73,lost,1st,West Indies,Kingston,6/28/2013,
+West Indies,won,6 wickets,73,won,2nd,Sri Lanka,Kingston,6/28/2013,
+Australia,won,6 wickets,79,lost,2nd,New Zealand,Sharjah,4/18/1998,Stephen Fleming (NZ)
+Australia,won,6 wickets,79,won,2nd,England,Jaipur,10/21/2006,
+England,lost,6 wickets,79,lost,1st,Australia,Jaipur,10/21/2006,
+New Zealand,lost,6 wickets,79,won,1st,Australia,Sharjah,4/18/1998,Stephen Fleming (NZ)
+England,won,6 wickets,84,won,2nd,West Indies,Bristol,5/24/2009,
+India,won,6 wickets,84,lost,2nd,West Indies,Dambulla,7/31/2005,
+West Indies,lost,6 wickets,84,lost,1st,England,Bristol,5/24/2009,
+West Indies,lost,6 wickets,84,won,1st,India,Dambulla,7/31/2005,
+New Zealand,lost,6 wickets,85,lost,1st,Sri Lanka,Christchurch,3/25/1997,Stephen Fleming (NZ)
+Sri Lanka,won,6 wickets,85,won,2nd,New Zealand,Christchurch,3/25/1997,Stephen Fleming (NZ)
+India,won,6 wickets,86,won,2nd,South Africa,Bangalore,11/19/2005,
+South Africa,lost,6 wickets,86,lost,1st,India,Bangalore,11/19/2005,
+India,won,6 wickets,88,lost,2nd,West Indies,Kochi,11/21/2013,
+West Indies,lost,6 wickets,88,won,1st,India,Kochi,11/21/2013,
+India,won,6 wickets,93,lost,2nd,Sri Lanka,Dambulla,8/16/2010,
+Sri Lanka,lost,6 wickets,93,won,1st,India,Dambulla,8/16/2010,
+Australia,won,6 wickets,97,lost,2nd,Pakistan,Adelaide,3/20/2015,
+Pakistan,lost,6 wickets,97,won,1st,Australia,Adelaide,3/20/2015,
+India,lost,6 wickets,111,won,1st,Pakistan,Dhaka,1/16/1998,
+Pakistan,won,6 wickets,111,lost,2nd,India,Dhaka,1/16/1998,
+New Zealand,won,6 wickets,117,won,2nd,Pakistan,Napier,2/20/2001,Stephen Fleming (NZ)
+Pakistan,lost,6 wickets,117,lost,1st,New Zealand,Napier,2/20/2001,Stephen Fleming (NZ)
+England,lost,6 wickets,120,won,1st,New Zealand,Wellington,2/9/2008,Daniel Vettori (NZ)
+New Zealand,won,6 wickets,120,lost,2nd,England,Wellington,2/9/2008,Daniel Vettori (NZ)
+South Africa,won,6 wickets,123,won,2nd,Sri Lanka,Johannesburg,11/27/2002,
+Sri Lanka,lost,6 wickets,123,lost,1st,South Africa,Johannesburg,11/27/2002,
+India,lost,6 wickets,128,lost,1st,New Zealand,Hamilton,1/14/2003,Stephen Fleming (NZ)
+New Zealand,won,6 wickets,128,won,2nd,India,Hamilton,1/14/2003,Stephen Fleming (NZ)
+Australia,lost,60 runs,0,lost,2nd,India,Bangalore,3/25/2001,
+India,won,60 runs,0,won,1st,Australia,Bangalore,3/25/2001,
+Pakistan,lost,60 runs,0,lost,2nd,West Indies,Port of Spain,4/22/2000,
+West Indies,won,60 runs,0,won,1st,Pakistan,Port of Spain,4/22/2000,
+Australia,lost,61 runs,0,won,2nd,South Africa,Port Elizabeth,4/13/2009,
+Australia,won,61 runs,0,won,1st,India,Bangalore,11/12/2003,
+England,lost,61 runs,0,won,2nd,West Indies,Birmingham,7/4/2007,
+India,lost,61 runs,0,lost,2nd,Australia,Bangalore,11/12/2003,
+New Zealand,lost,61 runs,0,lost,2nd,Sri Lanka,Napier,1/31/2001,Stephen Fleming (NZ)
+South Africa,won,61 runs,0,lost,1st,Australia,Port Elizabeth,4/13/2009,
+South Africa,won,61 runs,0,won,1st,West Indies,Durban,1/16/2015,
+Sri Lanka,won,61 runs,0,won,1st,New Zealand,Napier,1/31/2001,Stephen Fleming (NZ)
+West Indies,lost,61 runs,0,lost,2nd,South Africa,Durban,1/16/2015,
+West Indies,won,61 runs,0,lost,1st,England,Birmingham,7/4/2007,
+Australia,won,62 runs,0,lost,1st,South Africa,Harare,9/2/2014,
+England,won,62 runs,0,won,1st,Pakistan,Sharjah,4/12/1999,
+New Zealand,lost,62 runs,0,lost,2nd,South Africa,Durban,8/26/2015,
+New Zealand,lost,62 runs,0,won,2nd,Pakistan,Derby,5/28/1999,Stephen Fleming (NZ)
+Pakistan,lost,62 runs,0,lost,2nd,England,Sharjah,4/12/1999,
+Pakistan,lost,62 runs,0,lost,2nd,South Africa,East London,12/13/2002,
+Pakistan,lost,62 runs,0,won,2nd,South Africa,Nairobi (Gym),9/29/1996,
+Pakistan,won,62 runs,0,lost,1st,New Zealand,Derby,5/28/1999,Stephen Fleming (NZ)
+Pakistan,won,62 runs,0,won,1st,West Indies,Melbourne,1/20/1997,
+South Africa,lost,62 runs,0,won,2nd,Australia,Harare,9/2/2014,
+South Africa,won,62 runs,0,lost,1st,Pakistan,Nairobi (Gym),9/29/1996,
+South Africa,won,62 runs,0,won,1st,New Zealand,Durban,8/26/2015,
+South Africa,won,62 runs,0,won,1st,Pakistan,East London,12/13/2002,
+West Indies,lost,62 runs,0,lost,2nd,Pakistan,Melbourne,1/20/1997,
+Australia,won,63 runs,0,won,1st,Sri Lanka,Perth,2/15/2008,
+Australia,won,63 runs,0,won,1st,West Indies,St George's,6/27/2008,
+England,lost,63 runs,0,won,2nd,India,Birmingham,5/29/1999,
+India,won,63 runs,0,lost,1st,England,Birmingham,5/29/1999,
+India,won,63 runs,0,won,1st,Sri Lanka,Bristol,7/11/2002,
+Sri Lanka,lost,63 runs,0,lost,2nd,Australia,Perth,2/15/2008,
+Sri Lanka,lost,63 runs,0,lost,2nd,India,Bristol,7/11/2002,
+West Indies,lost,63 runs,0,lost,2nd,Australia,St George's,6/27/2008,
+Australia,won,64 runs,0,lost,1st,England,Lord's,9/5/2015,
+Australia,won,64 runs,0,won,1st,Sri Lanka,Sydney,3/8/2015,
+Australia,won,64 runs,0,won,1st,West Indies,Kingstown,3/16/2012,
+England,lost,64 runs,0,lost,2nd,South Africa,Port Elizabeth,1/21/1996,
+England,lost,64 runs,0,won,2nd,Australia,Lord's,9/5/2015,
+England,won,64 runs,0,lost,1st,India,The Oval,7/9/2002,
+India,lost,64 runs,0,won,2nd,England,The Oval,7/9/2002,
+New Zealand,won,64 runs,0,won,1st,Pakistan,Abu Dhabi,11/6/2009,Daniel Vettori (NZ)
+Pakistan,lost,64 runs,0,lost,2nd,New Zealand,Abu Dhabi,11/6/2009,Daniel Vettori (NZ)
+Pakistan,lost,64 runs,0,won,2nd,Sri Lanka,Karachi,6/29/2008,
+South Africa,won,64 runs,0,won,1st,England,Port Elizabeth,1/21/1996,
+Sri Lanka,lost,64 runs,0,lost,2nd,Australia,Sydney,3/8/2015,
+Sri Lanka,won,64 runs,0,lost,1st,Pakistan,Karachi,6/29/2008,
+West Indies,lost,64 runs,0,lost,2nd,Australia,Kingstown,3/16/2012,
+Australia,lost,65 runs,0,won,2nd,South Africa,Cape Town,4/9/2002,
+Australia,won,65 runs,0,lost,1st,India,Melbourne,2/5/2012,
+England,won,65 runs,0,won,1st,Sri Lanka,Dambulla,10/4/2007,
+India,lost,65 runs,0,won,2nd,Australia,Melbourne,2/5/2012,
+South Africa,won,65 runs,0,lost,1st,Australia,Cape Town,4/9/2002,
+Sri Lanka,lost,65 runs,0,lost,2nd,England,Dambulla,10/4/2007,
+Australia,won,66 runs,0,won,1st,New Zealand,Wellington,2/10/1998,Stephen Fleming (NZ)
+England,lost,66 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),3/25/2001,
+India,lost,66 runs,0,won,2nd,Pakistan,Amstelveen,8/21/2004,
+New Zealand,lost,66 runs,0,lost,2nd,Australia,Wellington,2/10/1998,Stephen Fleming (NZ)
+New Zealand,lost,66 runs,0,lost,2nd,Pakistan,Lahore,4/27/2002,Stephen Fleming (NZ)
+Pakistan,won,66 runs,0,lost,1st,India,Amstelveen,8/21/2004,
+Pakistan,won,66 runs,0,won,1st,New Zealand,Lahore,4/27/2002,
+Pakistan,won,66 runs,0,won,1st,New Zealand,Lahore,4/27/2002,Stephen Fleming (NZ)
+Pakistan,won,66 runs,0,won,1st,South Africa,Dubai (DSC),11/1/2013,
+South Africa,lost,66 runs,0,lost,2nd,Pakistan,Dubai (DSC),11/1/2013,
+South Africa,won,66 runs,0,lost,1st,Sri Lanka,Lahore,11/6/1997,
+South Africa,won,66 runs,0,lost,1st,West Indies,North Sound,5/22/2010,
+Sri Lanka,lost,66 runs,0,won,2nd,South Africa,Lahore,11/6/1997,
+Sri Lanka,won,66 runs,0,won,1st,England,Colombo (RPS),3/25/2001,
+West Indies,lost,66 runs,0,won,2nd,South Africa,North Sound,5/22/2010,
+Australia,lost,67 runs,0,lost,2nd,South Africa,Sydney,12/4/1997,
+Australia,won,67 runs,0,won,1st,West Indies,Port of Spain,5/24/2003,
+India,lost,67 runs,0,won,2nd,New Zealand,Colombo (RPS),7/26/2001,
+India,won,67 runs,0,won,1st,Sri Lanka,Colombo (RPS),2/5/2009,
+New Zealand,lost,67 runs,0,lost,2nd,South Africa,Perth,1/16/1998,Stephen Fleming (NZ)
+New Zealand,lost,67 runs,0,won,2nd,South Africa,Perth,2/1/2002,Stephen Fleming (NZ)
+New Zealand,won,67 runs,0,lost,1st,India,Colombo (RPS),7/26/2001,
+Pakistan,lost,67 runs,0,lost,2nd,South Africa,Birmingham,6/10/2013,
+Pakistan,won,67 runs,0,won,1st,South Africa,Sharjah,3/28/2000,
+South Africa,lost,67 runs,0,lost,2nd,Pakistan,Sharjah,3/28/2000,
+South Africa,won,67 runs,0,lost,1st,New Zealand,Perth,2/1/2002,Stephen Fleming (NZ)
+South Africa,won,67 runs,0,lost,1st,West Indies,St George's,4/10/2007,
+South Africa,won,67 runs,0,won,1st,Australia,Sydney,12/4/1997,
+South Africa,won,67 runs,0,won,1st,New Zealand,Perth,1/16/1998,Stephen Fleming (NZ)
+South Africa,won,67 runs,0,won,1st,Pakistan,Birmingham,6/10/2013,
+South Africa,won,67 runs,0,won,1st,West Indies,Roseau,5/28/2010,
+Sri Lanka,lost,67 runs,0,lost,2nd,India,Colombo (RPS),2/5/2009,
+West Indies,lost,67 runs,0,lost,2nd,Australia,Port of Spain,5/24/2003,
+West Indies,lost,67 runs,0,lost,2nd,South Africa,Roseau,5/28/2010,
+West Indies,lost,67 runs,0,won,2nd,South Africa,St George's,4/10/2007,
+India,lost,68 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),2/8/2009,
+India,lost,68 runs,0,won,2nd,Sri Lanka,Sharjah,10/27/2000,
+New Zealand,won,68 runs,0,won,1st,Pakistan,Abu Dhabi,12/19/2014,
+Pakistan,lost,68 runs,0,lost,2nd,New Zealand,Abu Dhabi,12/19/2014,
+Pakistan,lost,68 runs,0,lost,2nd,South Africa,Abu Dhabi,11/6/2013,
+South Africa,won,68 runs,0,won,1st,Pakistan,Abu Dhabi,11/6/2013,
+Sri Lanka,won,68 runs,0,lost,1st,India,Sharjah,10/27/2000,
+Sri Lanka,won,68 runs,0,won,1st,India,Colombo (RPS),2/8/2009,
+England,lost,69 runs,0,won,2nd,Sri Lanka,Leeds,7/1/2011,
+India,lost,69 runs,0,won,2nd,Sri Lanka,Port of Spain,3/23/2007,
+New Zealand,won,69 runs,0,lost,1st,Sri Lanka,Wellington,3/27/1997,Stephen Fleming (NZ)
+Sri Lanka,lost,69 runs,0,won,2nd,New Zealand,Wellington,3/27/1997,Stephen Fleming (NZ)
+Sri Lanka,won,69 runs,0,lost,1st,England,Leeds,7/1/2011,
+Sri Lanka,won,69 runs,0,lost,1st,India,Port of Spain,3/23/2007,
+Australia,lost,7 runs,0,lost,2nd,England,Brisbane,1/10/1999,
+Australia,lost,7 runs,0,lost,2nd,England,Sydney,1/17/1999,
+Australia,won,7 runs,0,won,1st,England,Hobart,1/11/2003,
+England,lost,7 runs,0,lost,2nd,Australia,Hobart,1/11/2003,
+England,lost,7 runs,0,lost,2nd,South Africa,East London,2/9/2005,
+England,lost,7 runs,0,won,2nd,Sri Lanka,Lord's,5/31/2014,
+England,won,7 runs,0,lost,1st,India,Sharjah,12/11/1997,
+England,won,7 runs,0,won,1st,Australia,Brisbane,1/10/1999,
+England,won,7 runs,0,won,1st,Australia,Sydney,1/17/1999,
+India,lost,7 runs,0,lost,1st,Pakistan,Peshawar,2/6/2006,
+India,lost,7 runs,0,won,2nd,England,Sharjah,12/11/1997,
+India,won,7 runs,0,won,1st,West Indies,Colombo (RPS),8/7/2005,
+New Zealand,won,7 runs,0,won,1st,Pakistan,Abu Dhabi,11/9/2009,Daniel Vettori (NZ)
+New Zealand,won,7 runs,0,won,1st,Pakistan,Abu Dhabi,12/17/2014,
+Pakistan,lost,7 runs,0,lost,2nd,New Zealand,Abu Dhabi,11/9/2009,Daniel Vettori (NZ)
+Pakistan,lost,7 runs,0,lost,2nd,New Zealand,Abu Dhabi,12/17/2014,
+Pakistan,won,7 runs,0,won,2nd,India,Peshawar,2/6/2006,
+South Africa,won,7 runs,0,won,1st,England,East London,2/9/2005,
+Sri Lanka,won,7 runs,0,lost,1st,England,Lord's,5/31/2014,
+West Indies,lost,7 runs,0,lost,2nd,India,Colombo (RPS),8/7/2005,
+South Africa,won,7 wickets,0,lost,2nd,West Indies,Roseau,5/30/2010,
+West Indies,lost,7 wickets,0,won,1st,South Africa,Roseau,5/30/2010,
+India,won,7 wickets,3,won,2nd,Pakistan,Toronto,9/20/1997,
+Pakistan,lost,7 wickets,3,lost,1st,India,Toronto,9/20/1997,
+India,lost,7 wickets,4,lost,1st,West Indies,Nagpur,11/9/2002,
+Pakistan,won,7 wickets,4,lost,2nd,Sri Lanka,Sharjah,11/2/2001,
+Sri Lanka,lost,7 wickets,4,won,1st,Pakistan,Sharjah,11/2/2001,
+West Indies,won,7 wickets,4,won,2nd,India,Nagpur,11/9/2002,
+England,lost,7 wickets,5,lost,1st,India,Indore,4/15/2006,
+England,lost,7 wickets,5,lost,1st,West Indies,Lord's,7/6/2004,
+England,won,7 wickets,5,won,2nd,India,Southampton,9/6/2011,
+India,lost,7 wickets,5,lost,1st,England,Southampton,9/6/2011,
+India,won,7 wickets,5,won,2nd,England,Indore,4/15/2006,
+South Africa,won,7 wickets,5,won,2nd,West Indies,Port of Spain,5/15/2005,
+West Indies,lost,7 wickets,5,lost,1st,South Africa,Port of Spain,5/15/2005,
+West Indies,won,7 wickets,5,won,2nd,England,Lord's,7/6/2004,
+Australia,lost,7 wickets,7,won,1st,West Indies,Brisbane,1/5/1997,
+West Indies,won,7 wickets,7,lost,2nd,Australia,Brisbane,1/5/1997,
+India,lost,7 wickets,8,lost,1st,West Indies,Kingston,6/16/2011,
+Pakistan,won,7 wickets,8,won,2nd,West Indies,Lahore,12/10/2006,
+South Africa,won,7 wickets,8,lost,2nd,West Indies,Port Elizabeth,1/27/2008,
+West Indies,lost,7 wickets,8,lost,1st,Pakistan,Lahore,12/10/2006,
+West Indies,lost,7 wickets,8,won,1st,South Africa,Port Elizabeth,1/27/2008,
+West Indies,won,7 wickets,8,won,2nd,India,Kingston,6/16/2011,
+New Zealand,lost,7 wickets,9,lost,1st,West Indies,Kingstown,4/6/1996,Lee Germon (NZ)
+West Indies,won,7 wickets,9,won,2nd,New Zealand,Kingstown,4/6/1996,Lee Germon (NZ)
+Australia,lost,7 wickets,10,won,1st,New Zealand,Napier,2/12/1998,Stephen Fleming (NZ)
+New Zealand,won,7 wickets,10,lost,2nd,Australia,Napier,2/12/1998,Stephen Fleming (NZ)
+Pakistan,won,7 wickets,10,lost,2nd,Sri Lanka,Dhaka,6/5/2000,
+Sri Lanka,lost,7 wickets,10,won,1st,Pakistan,Dhaka,6/5/2000,
+Australia,lost,7 wickets,11,lost,1st,England,Manchester,7/10/2012,
+England,won,7 wickets,11,won,2nd,Australia,Manchester,7/10/2012,
+India,lost,7 wickets,11,won,1st,New Zealand,Hamilton,1/28/2014,Brendon McCullum (NZ)
+India,won,7 wickets,11,lost,2nd,Sri Lanka,Kolkata,12/24/2009,
+New Zealand,lost,7 wickets,11,lost,1st,Sri Lanka,Pallekele,11/6/2012,Ross Taylor (NZ)
+New Zealand,won,7 wickets,11,lost,2nd,India,Hamilton,1/28/2014,Brendon McCullum (NZ)
+Sri Lanka,lost,7 wickets,11,won,1st,India,Kolkata,12/24/2009,
+Sri Lanka,won,7 wickets,11,won,2nd,New Zealand,Pallekele,11/6/2012,Ross Taylor (NZ)
+England,lost,7 wickets,12,won,1st,South Africa,Centurion,1/14/1996,
+Pakistan,won,7 wickets,12,won,2nd,West Indies,Gros Islet,4/25/2011,
+South Africa,won,7 wickets,12,lost,2nd,England,Centurion,1/14/1996,
+West Indies,lost,7 wickets,12,lost,1st,Pakistan,Gros Islet,4/25/2011,
+England,lost,7 wickets,14,won,1st,Pakistan,Karachi,3/3/1996,
+England,won,7 wickets,14,won,2nd,South Africa,Lord's,8/31/2008,
+Pakistan,won,7 wickets,14,lost,2nd,England,Karachi,3/3/1996,
+South Africa,lost,7 wickets,14,lost,1st,England,Lord's,8/31/2008,
+England,lost,7 wickets,15,won,1st,South Africa,Manchester,7/3/2003,
+South Africa,won,7 wickets,15,lost,2nd,England,Manchester,7/3/2003,
+Australia,won,7 wickets,16,lost,2nd,England,North Sound,4/8/2007,
+England,lost,7 wickets,16,won,1st,Australia,North Sound,4/8/2007,
+England,won,7 wickets,16,won,2nd,India,Dharamsala,1/27/2013,
+India,lost,7 wickets,16,lost,1st,England,Dharamsala,1/27/2013,
+Pakistan,won,7 wickets,16,lost,2nd,Sri Lanka,Sharjah,4/4/2003,
+Sri Lanka,lost,7 wickets,16,won,1st,Pakistan,Sharjah,4/4/2003,
+England,lost,7 wickets,17,lost,1st,Sri Lanka,The Oval,6/13/2013,
+India,lost,7 wickets,17,won,1st,West Indies,Port of Spain,6/1/2002,
+Sri Lanka,won,7 wickets,17,won,2nd,England,The Oval,6/13/2013,
+West Indies,won,7 wickets,17,lost,2nd,India,Port of Spain,6/1/2002,
+Australia,lost,7 wickets,18,won,1st,Pakistan,Abu Dhabi,5/3/2009,
+Pakistan,won,7 wickets,18,lost,2nd,Australia,Abu Dhabi,5/3/2009,
+Pakistan,won,7 wickets,19,won,2nd,West Indies,Karachi,12/16/2006,
+West Indies,lost,7 wickets,19,lost,1st,Pakistan,Karachi,12/16/2006,
+Australia,lost,7 wickets,20,lost,1st,South Africa,Harare,8/27/2014,
+England,lost,7 wickets,20,lost,1st,Pakistan,Lord's,9/2/2006,
+India,lost,7 wickets,20,won,1st,Sri Lanka,Colombo (RPS),8/25/1999,
+India,won,7 wickets,20,won,2nd,West Indies,Port of Spain,6/8/2011,
+Pakistan,won,7 wickets,20,won,2nd,England,Lord's,9/2/2006,
+South Africa,won,7 wickets,20,won,2nd,Australia,Harare,8/27/2014,
+Sri Lanka,won,7 wickets,20,lost,2nd,India,Colombo (RPS),8/25/1999,
+West Indies,lost,7 wickets,20,lost,1st,India,Port of Spain,6/8/2011,
+Australia,lost,7 wickets,22,lost,1st,Sri Lanka,Lahore,3/17/1996,
+New Zealand,won,7 wickets,22,won,2nd,Pakistan,Christchurch,1/10/2004,Stephen Fleming (NZ)
+Pakistan,lost,7 wickets,22,lost,1st,New Zealand,Christchurch,1/10/2004,Stephen Fleming (NZ)
+Sri Lanka,won,7 wickets,22,won,2nd,Australia,Lahore,3/17/1996,
+Australia,lost,7 wickets,23,won,1st,South Africa,Indore,10/19/1996,
+South Africa,lost,7 wickets,23,lost,1st,Sri Lanka,Dambulla,8/28/2004,
+South Africa,won,7 wickets,23,lost,2nd,Australia,Indore,10/19/1996,
+Sri Lanka,won,7 wickets,23,won,2nd,South Africa,Dambulla,8/28/2004,
+England,won,7 wickets,24,won,2nd,South Africa,Centurion,11/22/2009,
+South Africa,lost,7 wickets,24,lost,1st,England,Centurion,11/22/2009,
+Pakistan,lost,7 wickets,25,won,1st,South Africa,Rawalpindi,10/12/2003,
+South Africa,won,7 wickets,25,lost,2nd,Pakistan,Rawalpindi,10/12/2003,
+Australia,won,7 wickets,26,lost,2nd,Pakistan,Cardiff,6/9/2001,
+India,won,7 wickets,26,lost,2nd,New Zealand,Colombo (SSC),8/2/2001,Stephen Fleming (NZ)
+India,won,7 wickets,26,lost,2nd,Sri Lanka,Colombo (RPS),7/28/2001,
+New Zealand,lost,7 wickets,26,won,1st,India,Colombo (SSC),8/2/2001,Stephen Fleming (NZ)
+New Zealand,lost,7 wickets,26,won,1st,West Indies,Port of Spain,3/30/1996,Lee Germon (NZ)
+Pakistan,lost,7 wickets,26,won,1st,Australia,Cardiff,6/9/2001,
+Sri Lanka,lost,7 wickets,26,won,1st,India,Colombo (RPS),7/28/2001,
+West Indies,won,7 wickets,26,lost,2nd,New Zealand,Port of Spain,3/30/1996,Lee Germon (NZ)
+Sri Lanka,lost,7 wickets,27,lost,1st,West Indies,Port of Spain,4/12/2008,
+West Indies,won,7 wickets,27,won,2nd,Sri Lanka,Port of Spain,4/12/2008,
+England,won,7 wickets,28,lost,2nd,Sri Lanka,Melbourne,1/19/1999,
+Sri Lanka,lost,7 wickets,28,won,1st,England,Melbourne,1/19/1999,
+New Zealand,won,7 wickets,29,lost,2nd,Pakistan,Karachi,12/8/1996,Lee Germon (NZ)
+Pakistan,lost,7 wickets,29,won,1st,New Zealand,Karachi,12/8/1996,Lee Germon (NZ)
+Australia,won,7 wickets,30,lost,2nd,England,Sydney,12/13/2002,
+Australia,won,7 wickets,30,won,2nd,South Africa,Port Elizabeth,3/31/1997,
+England,lost,7 wickets,30,won,1st,Australia,Sydney,12/13/2002,
+India,lost,7 wickets,30,won,1st,Pakistan,Mohali,4/1/1999,
+Pakistan,won,7 wickets,30,lost,2nd,India,Mohali,4/1/1999,
+South Africa,lost,7 wickets,30,lost,1st,Australia,Port Elizabeth,3/31/1997,
+South Africa,lost,7 wickets,30,won,1st,West Indies,Centurion,2/1/2004,
+West Indies,won,7 wickets,30,lost,2nd,South Africa,Centurion,2/1/2004,
+India,won,7 wickets,31,won,2nd,Sri Lanka,Guwahati,12/22/1997,
+India,won,7 wickets,31,won,2nd,West Indies,Bridgetown,5/29/2002,
+Sri Lanka,lost,7 wickets,31,lost,1st,India,Guwahati,12/22/1997,
+West Indies,lost,7 wickets,31,lost,1st,India,Bridgetown,5/29/2002,
+Australia,won,7 wickets,34,won,2nd,England,Lord's,7/10/2005,
+England,lost,7 wickets,34,lost,1st,Australia,Lord's,7/10/2005,
+New Zealand,lost,7 wickets,34,lost,1st,Sri Lanka,Hambantota,11/10/2012,Ross Taylor (NZ)
+New Zealand,lost,7 wickets,34,lost,1st,West Indies,Southampton,5/24/1999,Stephen Fleming (NZ)
+Sri Lanka,won,7 wickets,34,won,2nd,New Zealand,Hambantota,11/10/2012,Ross Taylor (NZ)
+West Indies,won,7 wickets,34,won,2nd,New Zealand,Southampton,5/24/1999,Stephen Fleming (NZ)
+England,lost,7 wickets,36,won,1st,Pakistan,Lahore,12/12/2005,
+England,won,7 wickets,36,lost,2nd,New Zealand,Nottingham,6/17/2015,Brendon McCullum (NZ)
+India,won,7 wickets,36,lost,2nd,New Zealand,Delhi,11/17/1999,Stephen Fleming (NZ)
+India,won,7 wickets,36,won,2nd,Sri Lanka,Visakhapatnam,2/17/2007,
+New Zealand,lost,7 wickets,36,won,1st,England,Nottingham,6/17/2015,Brendon McCullum (NZ)
+New Zealand,lost,7 wickets,36,won,1st,India,Delhi,11/17/1999,Stephen Fleming (NZ)
+Pakistan,won,7 wickets,36,lost,2nd,England,Lahore,12/12/2005,
+Sri Lanka,lost,7 wickets,36,lost,1st,India,Visakhapatnam,2/17/2007,
+Australia,lost,7 wickets,38,won,1st,Pakistan,Abu Dhabi,8/31/2012,
+Australia,won,7 wickets,38,lost,2nd,England,Lord's,9/12/2009,
+England,lost,7 wickets,38,won,1st,Australia,Lord's,9/12/2009,
+New Zealand,won,7 wickets,38,won,2nd,West Indies,Taupo,1/4/2000,Stephen Fleming (NZ)
+Pakistan,won,7 wickets,38,lost,2nd,Australia,Abu Dhabi,8/31/2012,
+West Indies,lost,7 wickets,38,lost,1st,New Zealand,Taupo,1/4/2000,Stephen Fleming (NZ)
+India,won,7 wickets,39,won,2nd,Sri Lanka,Bulawayo,5/30/2010,
+Sri Lanka,lost,7 wickets,39,lost,1st,India,Bulawayo,5/30/2010,
+India,won,7 wickets,41,lost,2nd,Pakistan,Rawalpindi,2/11/2006,
+New Zealand,won,7 wickets,41,won,2nd,South Africa,Auckland,2/20/1999,Dion  Nash (NZ)
+Pakistan,lost,7 wickets,41,won,1st,India,Rawalpindi,2/11/2006,
+South Africa,lost,7 wickets,41,lost,1st,New Zealand,Auckland,2/20/1999,Dion  Nash (NZ)
+New Zealand,lost,7 wickets,42,won,1st,South Africa,Christchurch,2/17/1999,Dion  Nash (NZ)
+South Africa,won,7 wickets,42,lost,2nd,New Zealand,Christchurch,2/17/1999,Dion  Nash (NZ)
+South Africa,won,7 wickets,43,won,2nd,West Indies,Delhi,2/24/2011,
+West Indies,lost,7 wickets,43,lost,1st,South Africa,Delhi,2/24/2011,
+Australia,won,7 wickets,44,lost,2nd,Sri Lanka,St George's,4/16/2007,
+Sri Lanka,lost,7 wickets,44,won,1st,Australia,St George's,4/16/2007,
+Australia,won,7 wickets,45,lost,2nd,New Zealand,Adelaide,12/14/2007,Daniel Vettori (NZ)
+India,won,7 wickets,45,lost,2nd,Sri Lanka,Cuttack,12/21/2009,
+New Zealand,lost,7 wickets,45,won,1st,Australia,Adelaide,12/14/2007,Daniel Vettori (NZ)
+Sri Lanka,lost,7 wickets,45,won,1st,India,Cuttack,12/21/2009,
+Australia,won,7 wickets,49,lost,2nd,South Africa,Sydney,1/26/1998,
+India,lost,7 wickets,49,lost,1st,Sri Lanka,Colombo (RPS),8/20/1997,
+South Africa,lost,7 wickets,49,won,1st,Australia,Sydney,1/26/1998,
+Sri Lanka,won,7 wickets,49,won,2nd,India,Colombo (RPS),8/20/1997,
+South Africa,lost,7 wickets,50,lost,1st,Sri Lanka,Benoni,12/1/2002,
+South Africa,won,7 wickets,50,won,2nd,West Indies,Bridgetown,5/9/2001,
+Sri Lanka,won,7 wickets,50,won,2nd,South Africa,Benoni,12/1/2002,
+West Indies,lost,7 wickets,50,lost,1st,South Africa,Bridgetown,5/9/2001,
+New Zealand,lost,7 wickets,52,won,1st,Pakistan,Rawalpindi,12/5/2003,
+Pakistan,won,7 wickets,52,lost,2nd,New Zealand,Rawalpindi,12/5/2003,
+Australia,lost,7 wickets,54,won,1st,New Zealand,Auckland,3/3/2000,Stephen Fleming (NZ)
+New Zealand,won,7 wickets,54,lost,2nd,Australia,Auckland,3/3/2000,Stephen Fleming (NZ)
+Pakistan,won,7 wickets,55,lost,2nd,Sri Lanka,Colombo (RPS),7/22/2015,
+Sri Lanka,lost,7 wickets,55,won,1st,Pakistan,Colombo (RPS),7/22/2015,
+India,won,7 wickets,56,won,2nd,New Zealand,Centurion,3/14/2003,Stephen Fleming (NZ)
+New Zealand,lost,7 wickets,56,lost,1st,India,Centurion,3/14/2003,Stephen Fleming (NZ)
+Australia,won,7 wickets,57,won,2nd,West Indies,St George's,6/29/2008,
+West Indies,lost,7 wickets,57,lost,1st,Australia,St George's,6/29/2008,
+Australia,won,7 wickets,59,lost,2nd,India,Melbourne,2/6/2004,
+India,lost,7 wickets,59,won,1st,Australia,Melbourne,2/6/2004,
+Australia,lost,7 wickets,60,won,1st,Sri Lanka,Colombo (RPS),9/27/2002,
+Australia,won,7 wickets,60,lost,2nd,England,Sydney,1/19/2014,
+England,lost,7 wickets,60,won,1st,Australia,Sydney,1/19/2014,
+New Zealand,lost,7 wickets,60,won,1st,Sri Lanka,Colombo (RPS),6/21/1998,Stephen Fleming (NZ)
+New Zealand,lost,7 wickets,60,won,1st,Sri Lanka,Napier,12/28/2006,Daniel Vettori (NZ)
+New Zealand,lost,7 wickets,60,won,1st,West Indies,Gros Islet,6/9/2002,Stephen Fleming (NZ)
+Sri Lanka,won,7 wickets,60,lost,2nd,Australia,Colombo (RPS),9/27/2002,
+Sri Lanka,won,7 wickets,60,lost,2nd,New Zealand,Colombo (RPS),6/21/1998,Stephen Fleming (NZ)
+Sri Lanka,won,7 wickets,60,lost,2nd,New Zealand,Napier,12/28/2006,Daniel Vettori (NZ)
+West Indies,won,7 wickets,60,lost,2nd,New Zealand,Gros Islet,6/9/2002,Stephen Fleming (NZ)
+Pakistan,won,7 wickets,62,lost,2nd,West Indies,Toronto,9/19/1999,
+Sri Lanka,won,7 wickets,62,won,2nd,West Indies,Lahore,11/1/1997,
+West Indies,lost,7 wickets,62,lost,1st,Sri Lanka,Lahore,11/1/1997,
+West Indies,lost,7 wickets,62,won,1st,Pakistan,Toronto,9/19/1999,
+New Zealand,won,7 wickets,63,won,2nd,Pakistan,Wellington,1/31/2015,Brendon McCullum (NZ)
+Pakistan,lost,7 wickets,63,lost,1st,New Zealand,Wellington,1/31/2015,Brendon McCullum (NZ)
+New Zealand,won,7 wickets,64,won,2nd,West Indies,North Sound,3/29/2007,Stephen Fleming (NZ)
+Pakistan,lost,7 wickets,64,won,1st,South Africa,Nairobi (Gym),10/6/1996,
+South Africa,won,7 wickets,64,lost,2nd,Pakistan,Nairobi (Gym),10/6/1996,
+West Indies,lost,7 wickets,64,lost,1st,New Zealand,North Sound,3/29/2007,Stephen Fleming (NZ)
+New Zealand,won,7 wickets,68,lost,2nd,South Africa,Port Elizabeth,11/30/2007,Daniel Vettori (NZ)
+South Africa,lost,7 wickets,68,won,1st,New Zealand,Port Elizabeth,11/30/2007,Daniel Vettori (NZ)
+Australia,won,7 wickets,70,lost,2nd,New Zealand,Christchurch,2/8/1998,Stephen Fleming (NZ)
+New Zealand,lost,7 wickets,70,won,1st,Australia,Christchurch,2/8/1998,Stephen Fleming (NZ)
+Australia,won,7 wickets,71,lost,2nd,Sri Lanka,Pallekele,8/10/2011,
+Pakistan,lost,7 wickets,71,won,1st,Sri Lanka,Sharjah,10/27/2001,
+Sri Lanka,lost,7 wickets,71,won,1st,Australia,Pallekele,8/10/2011,
+Sri Lanka,won,7 wickets,71,lost,2nd,Pakistan,Sharjah,10/27/2001,
+Pakistan,lost,7 wickets,74,won,1st,South Africa,Multan,10/26/2007,
+South Africa,won,7 wickets,74,lost,2nd,Pakistan,Multan,10/26/2007,
+England,won,7 wickets,75,won,2nd,South Africa,The Oval,6/19/2013,
+India,lost,7 wickets,75,lost,1st,Sri Lanka,Dambulla,6/22/2010,
+Pakistan,lost,7 wickets,75,won,1st,South Africa,Colombo (SSC),7/12/2000,
+South Africa,lost,7 wickets,75,lost,1st,England,The Oval,6/19/2013,
+South Africa,won,7 wickets,75,lost,2nd,Pakistan,Colombo (SSC),7/12/2000,
+Sri Lanka,won,7 wickets,75,won,2nd,India,Dambulla,6/22/2010,
+Australia,won,7 wickets,76,won,2nd,New Zealand,The Oval,9/16/2004,Stephen Fleming (NZ)
+New Zealand,lost,7 wickets,76,lost,1st,Australia,The Oval,9/16/2004,Stephen Fleming (NZ)
+New Zealand,won,7 wickets,76,won,2nd,Sri Lanka,Queenstown,12/31/2005,Daniel Vettori (NZ)
+Sri Lanka,lost,7 wickets,76,lost,1st,New Zealand,Queenstown,12/31/2005,Daniel Vettori (NZ)
+India,won,7 wickets,80,won,2nd,Sri Lanka,Hobart,2/28/2012,
+Sri Lanka,lost,7 wickets,80,lost,1st,India,Hobart,2/28/2012,
+England,won,7 wickets,82,lost,2nd,India,Lord's,9/8/2007,
+India,lost,7 wickets,82,won,1st,England,Lord's,9/8/2007,
+Pakistan,lost,7 wickets,83,lost,1st,West Indies,Adelaide,12/17/1996,
+West Indies,won,7 wickets,83,won,2nd,Pakistan,Adelaide,12/17/1996,
+New Zealand,lost,7 wickets,84,won,1st,Sri Lanka,Mumbai (BS),10/20/2006,Stephen Fleming (NZ)
+Sri Lanka,won,7 wickets,84,lost,2nd,New Zealand,Mumbai (BS),10/20/2006,Stephen Fleming (NZ)
+Pakistan,lost,7 wickets,87,won,1st,South Africa,Centurion,4/17/1998,
+South Africa,won,7 wickets,87,lost,2nd,Pakistan,Centurion,4/17/1998,
+England,won,7 wickets,90,lost,2nd,South Africa,Leeds,5/24/1998,
+South Africa,lost,7 wickets,90,won,1st,England,Leeds,5/24/1998,
+India,won,7 wickets,91,won,2nd,Sri Lanka,Rajkot,11/9/2005,
+Pakistan,lost,7 wickets,91,won,1st,West Indies,Multan,12/13/2006,
+Sri Lanka,lost,7 wickets,91,lost,1st,India,Rajkot,11/9/2005,
+West Indies,won,7 wickets,91,lost,2nd,Pakistan,Multan,12/13/2006,
+India,won,7 wickets,92,lost,2nd,Pakistan,Toronto,9/14/1997,
+Pakistan,lost,7 wickets,92,won,1st,India,Toronto,9/14/1997,
+England,lost,7 wickets,93,won,1st,South Africa,Nottingham,9/5/2012,
+South Africa,won,7 wickets,93,lost,2nd,England,Nottingham,9/5/2012,
+Australia,won,7 wickets,94,won,2nd,New Zealand,Wellington,3/1/2005,Stephen Fleming (NZ)
+New Zealand,lost,7 wickets,94,lost,1st,Australia,Wellington,3/1/2005,Stephen Fleming (NZ)
+Australia,won,7 wickets,96,won,2nd,New Zealand,Nagpur,2/25/2011,Daniel Vettori (NZ)
+New Zealand,lost,7 wickets,96,lost,1st,Australia,Nagpur,2/25/2011,Daniel Vettori (NZ)
+Australia,won,7 wickets,101,lost,2nd,New Zealand,Melbourne,3/29/2015,Brendon McCullum (NZ)
+New Zealand,lost,7 wickets,101,won,1st,Australia,Melbourne,3/29/2015,Brendon McCullum (NZ)
+New Zealand,won,7 wickets,102,won,2nd,Sri Lanka,Auckland,12/26/2004,Stephen Fleming (NZ)
+Sri Lanka,lost,7 wickets,102,lost,1st,New Zealand,Auckland,12/26/2004,Stephen Fleming (NZ)
+Australia,won,7 wickets,103,won,2nd,Pakistan,Melbourne (Docklands),6/12/2002,
+Pakistan,lost,7 wickets,103,lost,1st,Australia,Melbourne (Docklands),6/12/2002,
+England,lost,7 wickets,106,lost,1st,West Indies,Nottingham,6/27/2004,
+England,won,7 wickets,106,won,2nd,India,Nottingham,9/1/2004,
+India,lost,7 wickets,106,lost,1st,England,Nottingham,9/1/2004,
+India,won,7 wickets,106,won,2nd,Sri Lanka,Hobart,2/26/2008,
+Sri Lanka,lost,7 wickets,106,lost,1st,India,Hobart,2/26/2008,
+West Indies,won,7 wickets,106,won,2nd,England,Nottingham,6/27/2004,
+India,won,7 wickets,107,won,2nd,West Indies,Johannesburg,9/30/2009,
+West Indies,lost,7 wickets,107,lost,1st,India,Johannesburg,9/30/2009,
+Pakistan,lost,7 wickets,108,won,1st,Sri Lanka,Colombo (RPS),7/21/2004,
+Sri Lanka,won,7 wickets,108,lost,2nd,Pakistan,Colombo (RPS),7/21/2004,
+Australia,won,7 wickets,111,lost,2nd,South Africa,Gros Islet,4/25/2007,
+South Africa,lost,7 wickets,111,won,1st,Australia,Gros Islet,4/25/2007,
+England,won,7 wickets,112,lost,2nd,South Africa,Port Elizabeth,11/29/2009,
+South Africa,lost,7 wickets,112,won,1st,England,Port Elizabeth,11/29/2009,
+Australia,lost,7 wickets,130,won,1st,South Africa,Perth,1/18/1998,
+South Africa,won,7 wickets,130,lost,2nd,Australia,Perth,1/18/1998,
+England,lost,7 wickets,131,lost,1st,India,Ranchi,1/19/2013,
+India,won,7 wickets,131,won,2nd,England,Ranchi,1/19/2013,
+Pakistan,lost,7 wickets,131,won,1st,West Indies,Southampton,9/22/2004,
+West Indies,won,7 wickets,131,lost,2nd,Pakistan,Southampton,9/22/2004,
+New Zealand,won,7 wickets,135,won,2nd,Pakistan,Dambulla,5/11/2003,Stephen Fleming (NZ)
+Pakistan,lost,7 wickets,135,lost,1st,New Zealand,Dambulla,5/11/2003,Stephen Fleming (NZ)
+Australia,lost,7 wickets,142,won,1st,South Africa,Centurion,4/5/2009,
+South Africa,won,7 wickets,142,lost,2nd,Australia,Centurion,4/5/2009,
+Sri Lanka,lost,7 wickets,143,won,1st,West Indies,Brisbane,1/5/1996,
+West Indies,won,7 wickets,143,lost,2nd,Sri Lanka,Brisbane,1/5/1996,
+India,lost,7 wickets,146,lost,1st,New Zealand,Queenstown,1/4/2003,Stephen Fleming (NZ)
+New Zealand,won,7 wickets,146,won,2nd,India,Queenstown,1/4/2003,Stephen Fleming (NZ)
+New Zealand,lost,7 wickets,148,won,1st,Pakistan,Sharjah,4/15/2001,
+Pakistan,won,7 wickets,148,lost,2nd,New Zealand,Sharjah,4/15/2001,
+England,won,7 wickets,168,lost,2nd,Pakistan,The Oval,6/20/2003,
+England,won,7 wickets,168,won,2nd,West Indies,Leeds,7/1/2004,
+Pakistan,lost,7 wickets,168,won,1st,England,The Oval,6/20/2003,
+West Indies,lost,7 wickets,168,lost,1st,England,Leeds,7/1/2004,
+New Zealand,won,7 wickets,174,lost,2nd,Sri Lanka,Christchurch,12/26/2015,Brendon McCullum (NZ)
+Sri Lanka,lost,7 wickets,174,won,1st,New Zealand,Christchurch,12/26/2015,Brendon McCullum (NZ)
+New Zealand,won,7 wickets,177,won,2nd,West Indies,Wellington,1/7/2009,Daniel Vettori (NZ)
+West Indies,lost,7 wickets,177,lost,1st,New Zealand,Wellington,1/7/2009,Daniel Vettori (NZ)
+England,won,7 wickets,178,won,2nd,South Africa,Lord's,7/12/2003,
+Pakistan,lost,7 wickets,178,won,1st,Sri Lanka,Dambulla,8/30/2014,
+South Africa,lost,7 wickets,178,lost,1st,England,Lord's,7/12/2003,
+Sri Lanka,won,7 wickets,178,lost,2nd,Pakistan,Dambulla,8/30/2014,
+England,lost,7 wickets,196,lost,1st,New Zealand,Chester-le-Street,6/29/2004,Stephen Fleming (NZ)
+New Zealand,won,7 wickets,196,won,2nd,England,Chester-le-Street,6/29/2004,Stephen Fleming (NZ)
+England,won,70 runs,0,lost,1st,India,The Oval,9/3/2004,
+India,lost,70 runs,0,lost,2nd,West Indies,Toronto,9/12/1999,
+India,lost,70 runs,0,won,2nd,England,The Oval,9/3/2004,
+India,lost,70 runs,0,won,2nd,New Zealand,Christchurch,1/19/1999,Dion  Nash (NZ)
+New Zealand,won,70 runs,0,lost,1st,India,Christchurch,1/19/1999,Dion  Nash (NZ)
+West Indies,won,70 runs,0,won,1st,India,Toronto,9/12/1999,
+India,lost,71 runs,0,lost,2nd,Sri Lanka,Dhaka,6/1/2000,
+Sri Lanka,won,71 runs,0,won,1st,India,Dhaka,6/1/2000,
+Australia,won,72 runs,0,won,1st,India,Pune,10/13/2013,
+India,lost,72 runs,0,lost,2nd,Australia,Pune,10/13/2013,
+New Zealand,lost,72 runs,0,won,2nd,South Africa,Mount Maunganui,10/24/2014,Brendon McCullum (NZ)
+South Africa,won,72 runs,0,lost,1st,New Zealand,Mount Maunganui,10/24/2014,Brendon McCullum (NZ)
+Australia,won,73 runs,0,won,1st,South Africa,Canberra,11/19/2014,
+Australia,won,73 runs,0,won,1st,West Indies,Adelaide,1/26/2005,
+South Africa,lost,73 runs,0,lost,2nd,Australia,Canberra,11/19/2014,
+West Indies,lost,73 runs,0,lost,2nd,Australia,Adelaide,1/26/2005,
+Australia,won,74 runs,0,won,1st,West Indies,Melbourne,1/11/2001,
+India,lost,74 runs,0,lost,2nd,Sri Lanka,Dambulla,8/28/2010,
+India,won,74 runs,0,won,1st,South Africa,Mumbai,12/14/1996,
+New Zealand,lost,74 runs,0,lost,2nd,South Africa,Birmingham,6/10/1999,Stephen Fleming (NZ)
+South Africa,lost,74 runs,0,lost,2nd,India,Mumbai,12/14/1996,
+South Africa,won,74 runs,0,won,1st,New Zealand,Birmingham,6/10/1999,Stephen Fleming (NZ)
+Sri Lanka,won,74 runs,0,won,1st,India,Dambulla,8/28/2010,
+West Indies,lost,74 runs,0,lost,2nd,Australia,Melbourne,1/11/2001,
+Pakistan,lost,75 runs,0,won,2nd,Sri Lanka,Sharjah,11/8/1996,
+South Africa,won,75 runs,0,won,1st,Sri Lanka,Colombo (RPS),7/6/2014,
+Sri Lanka,lost,75 runs,0,lost,2nd,South Africa,Colombo (RPS),7/6/2014,
+Sri Lanka,won,75 runs,0,lost,1st,Pakistan,Sharjah,11/8/1996,
+India,won,76 runs,0,won,1st,Pakistan,Adelaide,2/15/2015,
+Pakistan,lost,76 runs,0,lost,2nd,India,Adelaide,2/15/2015,
+Pakistan,lost,76 runs,0,lost,2nd,Sri Lanka,Pallekele,6/9/2012,
+South Africa,lost,76 runs,0,lost,2nd,Sri Lanka,Hobart,2/7/2006,
+Sri Lanka,won,76 runs,0,won,1st,Pakistan,Pallekele,6/9/2012,
+Sri Lanka,won,76 runs,0,won,1st,South Africa,Hobart,2/7/2006,
+Australia,lost,77 runs,0,lost,2nd,New Zealand,Adelaide,1/26/2002,Stephen Fleming (NZ)
+Australia,won,77 runs,0,lost,1st,India,The Oval,6/4/1999,
+Australia,won,77 runs,0,won,1st,India,Mumbai,11/1/2003,
+India,lost,77 runs,0,lost,2nd,Australia,Mumbai,11/1/2003,
+India,lost,77 runs,0,won,2nd,Australia,The Oval,6/4/1999,
+India,lost,77 runs,0,won,2nd,Pakistan,Toronto,9/16/1998,
+New Zealand,won,77 runs,0,won,1st,Australia,Adelaide,1/26/2002,Stephen Fleming (NZ)
+Pakistan,lost,77 runs,0,lost,2nd,Sri Lanka,Hambantota,8/26/2014,
+Pakistan,lost,77 runs,0,lost,2nd,Sri Lanka,Sharjah,4/20/2001,
+Pakistan,won,77 runs,0,lost,1st,India,Toronto,9/16/1998,
+Sri Lanka,won,77 runs,0,won,1st,Pakistan,Hambantota,8/26/2014,
+Sri Lanka,won,77 runs,0,won,1st,Pakistan,Sharjah,4/20/2001,
+Australia,lost,78 runs,0,won,2nd,Sri Lanka,Hambantota,8/16/2011,
+Australia,won,78 runs,0,lost,1st,England,The Oval,6/30/2010,
+Australia,won,78 runs,0,won,1st,West Indies,Kuala Lumpur,9/12/2006,
+England,lost,78 runs,0,lost,2nd,South Africa,Rawalpindi,2/25/1996,
+England,lost,78 runs,0,won,2nd,Australia,The Oval,6/30/2010,
+South Africa,won,78 runs,0,lost,1st,Sri Lanka,Ahmedabad,10/24/2006,
+South Africa,won,78 runs,0,won,1st,England,Rawalpindi,2/25/1996,
+Sri Lanka,lost,78 runs,0,won,2nd,South Africa,Ahmedabad,10/24/2006,
+Sri Lanka,won,78 runs,0,lost,1st,Australia,Hambantota,8/16/2011,
+West Indies,lost,78 runs,0,lost,2nd,Australia,Kuala Lumpur,9/12/2006,
+Australia,lost,79 runs,0,won,2nd,Sri Lanka,Sydney,1/9/2003,
+England,won,79 runs,0,lost,1st,West Indies,Lord's,7/1/2007,
+New Zealand,won,79 runs,0,lost,1st,Sri Lanka,Sharjah,4/17/2001,
+Pakistan,won,79 runs,0,lost,1st,Sri Lanka,Dambulla,5/10/2003,
+Sri Lanka,lost,79 runs,0,won,2nd,New Zealand,Sharjah,4/17/2001,
+Sri Lanka,lost,79 runs,0,won,2nd,Pakistan,Dambulla,5/10/2003,
+Sri Lanka,won,79 runs,0,lost,1st,Australia,Sydney,1/9/2003,
+West Indies,lost,79 runs,0,won,2nd,England,Lord's,7/1/2007,
+Australia,lost,8 runs,0,lost,2nd,India,Chandigarh,10/8/2007,
+Australia,lost,8 runs,0,lost,2nd,South Africa,Melbourne (Docklands),8/20/2000,
+Australia,won,8 runs,0,won,1st,New Zealand,Perth,1/28/2007,Stephen Fleming (NZ)
+Australia,won,8 runs,0,won,1st,South Africa,Johannesburg,4/8/1997,
+England,won,8 runs,0,won,1st,Pakistan,Sharjah,12/15/1997,
+India,lost,8 runs,0,won,2nd,Sri Lanka,Colombo (SSC),7/1/1998,
+India,won,8 runs,0,won,1st,Australia,Chandigarh,10/8/2007,
+New Zealand,lost,8 runs,0,lost,2nd,Australia,Perth,1/28/2007,Stephen Fleming (NZ)
+Pakistan,lost,8 runs,0,lost,2nd,England,Sharjah,12/15/1997,
+Pakistan,lost,8 runs,0,lost,2nd,South Africa,Tangier,8/18/2002,
+Pakistan,won,8 runs,0,won,1st,South Africa,Lahore,10/3/2003,
+South Africa,lost,8 runs,0,lost,2nd,Australia,Johannesburg,4/8/1997,
+South Africa,lost,8 runs,0,lost,2nd,Pakistan,Lahore,10/3/2003,
+South Africa,won,8 runs,0,won,1st,Australia,Melbourne (Docklands),8/20/2000,
+South Africa,won,8 runs,0,won,1st,Pakistan,Tangier,8/18/2002,
+Sri Lanka,won,8 runs,0,lost,1st,India,Colombo (SSC),7/1/1998,
+South Africa,won,8 wickets,7,lost,2nd,Sri Lanka,Paarl,1/9/2001,
+Sri Lanka,lost,8 wickets,7,won,1st,South Africa,Paarl,1/9/2001,
+Pakistan,won,8 wickets,8,lost,2nd,Sri Lanka,Karachi,10/6/2004,
+Sri Lanka,lost,8 wickets,8,won,1st,Pakistan,Karachi,10/6/2004,
+Sri Lanka,won,8 wickets,9,lost,2nd,West Indies,Colombo (RPS),11/4/2015,
+West Indies,lost,8 wickets,9,won,1st,Sri Lanka,Colombo (RPS),11/4/2015,
+India,lost,8 wickets,12,lost,1st,Sri Lanka,Canberra,2/12/2008,
+Sri Lanka,won,8 wickets,12,won,2nd,India,Canberra,2/12/2008,
+Australia,lost,8 wickets,13,lost,1st,England,Chester-le-Street,7/7/2012,
+Australia,won,8 wickets,13,won,2nd,South Africa,Durban,4/3/2002,
+England,won,8 wickets,13,won,2nd,Australia,Chester-le-Street,7/7/2012,
+South Africa,lost,8 wickets,13,lost,1st,Australia,Durban,4/3/2002,
+South Africa,won,8 wickets,13,won,2nd,West Indies,Johannesburg,2/3/2008,
+West Indies,lost,8 wickets,13,lost,1st,South Africa,Johannesburg,2/3/2008,
+England,won,8 wickets,14,won,2nd,New Zealand,Napier,2/20/2013,Brendon McCullum (NZ)
+New Zealand,lost,8 wickets,14,lost,1st,England,Napier,2/20/2013,Brendon McCullum (NZ)
+India,won,8 wickets,17,won,2nd,Pakistan,Birmingham,6/15/2013,
+Pakistan,lost,8 wickets,17,lost,1st,India,Birmingham,6/15/2013,
+Australia,lost,8 wickets,18,won,1st,West Indies,Bridgetown,4/25/1999,
+West Indies,won,8 wickets,18,lost,2nd,Australia,Bridgetown,4/25/1999,
+England,won,8 wickets,19,won,2nd,Sri Lanka,Lord's,5/14/1999,
+India,won,8 wickets,19,won,2nd,Pakistan,Karachi,2/19/2006,
+India,won,8 wickets,19,won,2nd,Pakistan,Toronto,9/16/1996,
+Pakistan,lost,8 wickets,19,lost,1st,India,Karachi,2/19/2006,
+Pakistan,lost,8 wickets,19,lost,1st,India,Toronto,9/16/1996,
+Sri Lanka,lost,8 wickets,19,lost,1st,England,Lord's,5/14/1999,
+Pakistan,won,8 wickets,20,lost,2nd,Sri Lanka,Sharjah,11/12/1996,
+Sri Lanka,lost,8 wickets,20,won,1st,Pakistan,Sharjah,11/12/1996,
+England,won,8 wickets,22,lost,2nd,Pakistan,Nottingham,9/8/2006,
+New Zealand,lost,8 wickets,22,won,1st,Sri Lanka,Nelson,12/31/2015,
+Pakistan,lost,8 wickets,22,won,1st,England,Nottingham,9/8/2006,
+Sri Lanka,won,8 wickets,22,lost,2nd,New Zealand,Nelson,12/31/2015,
+Australia,won,8 wickets,23,lost,2nd,Sri Lanka,Sydney,1/13/1999,
+South Africa,won,8 wickets,23,won,2nd,West Indies,St George's,5/6/2001,
+Sri Lanka,lost,8 wickets,23,won,1st,Australia,Sydney,1/13/1999,
+West Indies,lost,8 wickets,23,lost,1st,South Africa,St George's,5/6/2001,
+Pakistan,won,8 wickets,25,lost,2nd,Sri Lanka,Karachi,1/20/2009,
+South Africa,won,8 wickets,25,won,2nd,West Indies,St John's,5/2/2001,
+Sri Lanka,lost,8 wickets,25,won,1st,Pakistan,Karachi,1/20/2009,
+West Indies,lost,8 wickets,25,lost,1st,South Africa,St John's,5/2/2001,
+India,lost,8 wickets,27,won,1st,Pakistan,Karachi,7/2/2008,
+Pakistan,won,8 wickets,27,lost,2nd,India,Karachi,7/2/2008,
+Sri Lanka,won,8 wickets,27,won,2nd,West Indies,Colombo (SSC),2/3/2011,
+West Indies,lost,8 wickets,27,lost,1st,Sri Lanka,Colombo (SSC),2/3/2011,
+Australia,won,8 wickets,28,lost,2nd,England,Melbourne,1/12/2007,
+England,lost,8 wickets,28,won,1st,Australia,Melbourne,1/12/2007,
+Australia,won,8 wickets,29,lost,2nd,India,Pune,3/28/2001,
+India,lost,8 wickets,29,won,1st,Australia,Pune,3/28/2001,
+New Zealand,lost,8 wickets,29,won,1st,South Africa,Melbourne,2/6/2002,Stephen Fleming (NZ)
+South Africa,won,8 wickets,29,lost,2nd,New Zealand,Melbourne,2/6/2002,Stephen Fleming (NZ)
+Australia,lost,8 wickets,30,won,1st,South Africa,Guwahati,11/1/1996,
+England,won,8 wickets,30,won,2nd,West Indies,The Oval,6/19/2012,
+India,lost,8 wickets,30,lost,1st,Pakistan,Singapore,4/5/1996,
+Pakistan,won,8 wickets,30,won,2nd,India,Singapore,4/5/1996,
+South Africa,won,8 wickets,30,lost,2nd,Australia,Guwahati,11/1/1996,
+South Africa,won,8 wickets,30,lost,2nd,West Indies,Kingston,5/7/2005,
+West Indies,lost,8 wickets,30,lost,1st,England,The Oval,6/19/2012,
+West Indies,lost,8 wickets,30,won,1st,South Africa,Kingston,5/7/2005,
+India,lost,8 wickets,31,won,1st,West Indies,Port of Spain,4/26/1997,
+West Indies,won,8 wickets,31,lost,2nd,India,Port of Spain,4/26/1997,
+New Zealand,won,8 wickets,33,lost,2nd,South Africa,Potchefstroom,8/23/2015,
+South Africa,lost,8 wickets,33,won,1st,New Zealand,Potchefstroom,8/23/2015,
+Australia,lost,8 wickets,34,won,1st,Sri Lanka,Adelaide,3/6/2012,
+Australia,won,8 wickets,34,lost,2nd,Pakistan,Abu Dhabi,5/1/2009,
+England,lost,8 wickets,34,lost,1st,Pakistan,Lahore,10/27/2000,
+Pakistan,lost,8 wickets,34,won,1st,Australia,Abu Dhabi,5/1/2009,
+Pakistan,won,8 wickets,34,won,2nd,England,Lahore,10/27/2000,
+Sri Lanka,won,8 wickets,34,lost,2nd,Australia,Adelaide,3/6/2012,
+South Africa,lost,8 wickets,36,won,1st,Sri Lanka,Pallekele,7/28/2013,
+Sri Lanka,won,8 wickets,36,lost,2nd,South Africa,Pallekele,7/28/2013,
+India,won,8 wickets,38,lost,2nd,Sri Lanka,Colombo (RPS),6/19/1998,
+South Africa,won,8 wickets,38,won,2nd,West Indies,Kingston,5/8/2005,
+Sri Lanka,lost,8 wickets,38,won,1st,India,Colombo (RPS),6/19/1998,
+West Indies,lost,8 wickets,38,lost,1st,South Africa,Kingston,5/8/2005,
+Australia,won,8 wickets,41,lost,2nd,West Indies,Mumbai (BS),11/5/2006,
+Sri Lanka,won,8 wickets,41,won,2nd,West Indies,Kandy,12/15/2001,
+West Indies,lost,8 wickets,41,lost,1st,Sri Lanka,Kandy,12/15/2001,
+West Indies,lost,8 wickets,41,won,1st,Australia,Mumbai (BS),11/5/2006,
+India,won,8 wickets,42,won,2nd,New Zealand,Jaipur,12/1/2010,Daniel Vettori (NZ)
+New Zealand,lost,8 wickets,42,lost,1st,India,Jaipur,12/1/2010,Daniel Vettori (NZ)
+New Zealand,lost,8 wickets,42,lost,1st,India,Jaipur,12/1/2010,Ross Taylor (NZ)
+India,won,8 wickets,45,lost,2nd,New Zealand,Bangalore,5/14/1997,Stephen Fleming (NZ)
+New Zealand,lost,8 wickets,45,won,1st,India,Bangalore,5/14/1997,Stephen Fleming (NZ)
+England,lost,8 wickets,46,won,1st,Sri Lanka,Chester-le-Street,6/24/2006,
+Sri Lanka,won,8 wickets,46,lost,2nd,England,Chester-le-Street,6/24/2006,
+New Zealand,lost,8 wickets,47,won,1st,Pakistan,Sharjah,4/12/2001,
+Pakistan,won,8 wickets,47,lost,2nd,New Zealand,Sharjah,4/12/2001,
+Australia,won,8 wickets,48,lost,2nd,West Indies,Sydney,12/8/1996,
+West Indies,lost,8 wickets,48,won,1st,Australia,Sydney,12/8/1996,
+Pakistan,won,8 wickets,51,lost,2nd,West Indies,Gros Islet,4/23/2011,
+West Indies,lost,8 wickets,51,won,1st,Pakistan,Gros Islet,4/23/2011,
+Australia,won,8 wickets,53,lost,2nd,India,Galle,8/23/1999,
+India,lost,8 wickets,53,won,1st,Australia,Galle,8/23/1999,
+India,won,8 wickets,53,lost,2nd,Pakistan,Dhaka,1/14/1998,
+Pakistan,lost,8 wickets,53,won,1st,India,Dhaka,1/14/1998,
+Pakistan,won,8 wickets,53,lost,2nd,Sri Lanka,Abu Dhabi,12/25/2013,
+Sri Lanka,lost,8 wickets,53,won,1st,Pakistan,Abu Dhabi,12/25/2013,
+England,lost,8 wickets,56,won,1st,India,Kanpur,1/28/2002,
+India,won,8 wickets,56,lost,2nd,England,Kanpur,1/28/2002,
+Pakistan,won,8 wickets,56,won,2nd,West Indies,Lahore,11/4/1997,
+West Indies,lost,8 wickets,56,lost,1st,Pakistan,Lahore,11/4/1997,
+Australia,lost,8 wickets,59,lost,1st,Sri Lanka,Adelaide,1/13/2013,
+Sri Lanka,won,8 wickets,59,won,2nd,Australia,Adelaide,1/13/2013,
+Pakistan,lost,8 wickets,60,lost,1st,Sri Lanka,Lahore,11/5/1997,
+Sri Lanka,won,8 wickets,60,won,2nd,Pakistan,Lahore,11/5/1997,
+Australia,lost,8 wickets,63,won,1st,Sri Lanka,Colombo (RPS),8/31/1999,
+England,lost,8 wickets,63,won,1st,India,Colombo (RPS),9/22/2002,
+India,won,8 wickets,63,lost,2nd,England,Colombo (RPS),9/22/2002,
+Pakistan,lost,8 wickets,63,won,1st,South Africa,Abu Dhabi,10/29/2010,
+South Africa,won,8 wickets,63,lost,2nd,Pakistan,Abu Dhabi,10/29/2010,
+Sri Lanka,won,8 wickets,63,lost,2nd,Australia,Colombo (RPS),8/31/1999,
+England,lost,8 wickets,64,won,1st,Sri Lanka,Colombo (RPS),11/29/2014,
+Pakistan,won,8 wickets,64,won,2nd,West Indies,Sydney,1/14/1997,
+Sri Lanka,won,8 wickets,64,lost,2nd,England,Colombo (RPS),11/29/2014,
+West Indies,lost,8 wickets,64,lost,1st,Pakistan,Sydney,1/14/1997,
+England,lost,8 wickets,65,won,1st,South Africa,Nairobi (Gym),10/10/2000,
+India,won,8 wickets,65,won,2nd,West Indies,The Oval,6/11/2013,
+South Africa,won,8 wickets,65,lost,2nd,England,Nairobi (Gym),10/10/2000,
+West Indies,lost,8 wickets,65,lost,1st,India,The Oval,6/11/2013,
+Australia,won,8 wickets,70,lost,2nd,Sri Lanka,Hambantota,8/14/2011,
+Sri Lanka,lost,8 wickets,70,won,1st,Australia,Hambantota,8/14/2011,
+Australia,lost,8 wickets,71,won,1st,South Africa,Adelaide,1/26/2009,
+South Africa,won,8 wickets,71,lost,2nd,Australia,Adelaide,1/26/2009,
+England,lost,8 wickets,75,won,1st,Sri Lanka,Leeds,7/1/2006,
+India,won,8 wickets,75,won,2nd,West Indies,Toronto,9/11/1999,
+Sri Lanka,won,8 wickets,75,lost,2nd,England,Leeds,7/1/2006,
+West Indies,lost,8 wickets,75,lost,1st,India,Toronto,9/11/1999,
+India,lost,8 wickets,79,won,1st,Sri Lanka,Colombo (RPS),7/26/1997,
+Sri Lanka,won,8 wickets,79,lost,2nd,India,Colombo (RPS),7/26/1997,
+England,lost,8 wickets,80,won,1st,India,Delhi,10/17/2011,
+India,won,8 wickets,80,lost,2nd,England,Delhi,10/17/2011,
+New Zealand,won,8 wickets,81,won,2nd,West Indies,Wellington,1/8/2000,Stephen Fleming (NZ)
+West Indies,lost,8 wickets,81,lost,1st,New Zealand,Wellington,1/8/2000,Stephen Fleming (NZ)
+Pakistan,lost,8 wickets,83,won,1st,Sri Lanka,Colombo (RPS),9/12/2002,
+Sri Lanka,won,8 wickets,83,lost,2nd,Pakistan,Colombo (RPS),9/12/2002,
+Australia,won,8 wickets,89,lost,2nd,West Indies,Kingston,5/18/2003,
+West Indies,lost,8 wickets,89,won,1st,Australia,Kingston,5/18/2003,
+India,won,8 wickets,90,won,2nd,Sri Lanka,Cardiff,6/20/2013,
+Sri Lanka,lost,8 wickets,90,lost,1st,India,Cardiff,6/20/2013,
+Australia,won,8 wickets,91,won,2nd,England,The Oval,7/12/2005,
+England,lost,8 wickets,91,lost,1st,Australia,The Oval,7/12/2005,
+India,lost,8 wickets,91,won,1st,Sri Lanka,Dambulla,8/18/2008,
+Sri Lanka,won,8 wickets,91,lost,2nd,India,Dambulla,8/18/2008,
+India,lost,8 wickets,95,won,1st,West Indies,Kingston,6/28/2009,
+West Indies,won,8 wickets,95,lost,2nd,India,Kingston,6/28/2009,
+New Zealand,lost,8 wickets,96,won,1st,South Africa,Singapore,8/25/2000,Stephen Fleming (NZ)
+South Africa,won,8 wickets,96,lost,2nd,New Zealand,Singapore,8/25/2000,Stephen Fleming (NZ)
+Australia,lost,8 wickets,101,won,1st,Sri Lanka,Sydney,2/17/2012,
+Pakistan,lost,8 wickets,101,won,1st,South Africa,Sharjah,4/16/1996,
+South Africa,won,8 wickets,101,lost,2nd,Pakistan,Sharjah,4/16/1996,
+Sri Lanka,won,8 wickets,101,lost,2nd,Australia,Sydney,2/17/2012,
+India,won,8 wickets,104,lost,2nd,Sri Lanka,Dhaka,1/10/2010,
+Sri Lanka,lost,8 wickets,104,won,1st,India,Dhaka,1/10/2010,
+New Zealand,lost,8 wickets,105,won,1st,Pakistan,Sharjah,4/15/2002,Stephen Fleming (NZ)
+Pakistan,won,8 wickets,105,lost,2nd,New Zealand,Sharjah,4/15/2002,Stephen Fleming (NZ)
+South Africa,won,8 wickets,115,won,2nd,Sri Lanka,Kimberley,12/4/2002,
+Sri Lanka,lost,8 wickets,115,lost,1st,South Africa,Kimberley,12/4/2002,
+India,lost,8 wickets,118,won,1st,New Zealand,Auckland,3/14/2009,Daniel Vettori (NZ)
+New Zealand,won,8 wickets,118,lost,2nd,India,Auckland,3/14/2009,Daniel Vettori (NZ)
+Australia,won,8 wickets,119,lost,2nd,England,The Oval,6/21/2001,
+England,lost,8 wickets,119,won,1st,Australia,The Oval,6/21/2001,
+India,lost,8 wickets,132,won,1st,Pakistan,Sharjah,4/16/1999,
+Pakistan,won,8 wickets,132,lost,2nd,India,Sharjah,4/16/1999,
+South Africa,lost,8 wickets,135,lost,1st,Sri Lanka,Colombo (SSC),7/11/2000,
+Sri Lanka,won,8 wickets,135,won,2nd,South Africa,Colombo (SSC),7/11/2000,
+Australia,won,8 wickets,141,lost,2nd,West Indies,Adelaide,2/9/2010,
+West Indies,lost,8 wickets,141,won,1st,Australia,Adelaide,2/9/2010,
+Australia,won,8 wickets,154,lost,2nd,England,Manchester,9/13/2015,
+England,lost,8 wickets,154,won,1st,Australia,Manchester,9/13/2015,
+New Zealand,won,8 wickets,163,won,2nd,Pakistan,Napier,1/14/2004,Stephen Fleming (NZ)
+Pakistan,lost,8 wickets,163,lost,1st,New Zealand,Napier,1/14/2004,Stephen Fleming (NZ)
+India,won,8 wickets,164,lost,2nd,South Africa,Nairobi (Gym),9/26/1999,
+South Africa,lost,8 wickets,164,won,1st,India,Nairobi (Gym),9/26/1999,
+Pakistan,won,8 wickets,169,lost,2nd,Sri Lanka,Dubai (DSC),11/11/2011,
+Sri Lanka,lost,8 wickets,169,won,1st,Pakistan,Dubai (DSC),11/11/2011,
+Australia,won,8 wickets,170,lost,2nd,Sri Lanka,Brisbane,11/7/2010,
+Sri Lanka,lost,8 wickets,170,won,1st,Australia,Brisbane,11/7/2010,
+India,won,8 wickets,173,lost,2nd,New Zealand,Chennai,12/10/2010,Daniel Vettori (NZ)
+New Zealand,lost,8 wickets,173,won,1st,India,Chennai,12/10/2010,Daniel Vettori (NZ)
+England,lost,8 wickets,176,lost,1st,West Indies,Bridgetown,3/27/2009,
+West Indies,won,8 wickets,176,won,2nd,England,Bridgetown,3/27/2009,
+India,won,8 wickets,178,won,2nd,Sri Lanka,Mohali,10/28/2005,
+Sri Lanka,lost,8 wickets,178,lost,1st,India,Mohali,10/28/2005,
+Australia,won,8 wickets,179,lost,2nd,Pakistan,Lord's,6/20/1999,
+Pakistan,lost,8 wickets,179,won,1st,Australia,Lord's,6/20/1999,
+Australia,won,8 wickets,188,lost,2nd,South Africa,Sydney,1/22/2002,
+South Africa,lost,8 wickets,188,won,1st,Australia,Sydney,1/22/2002,
+Australia,won,8 wickets,200,lost,2nd,New Zealand,Faridabad,10/29/2003,Stephen Fleming (NZ)
+New Zealand,lost,8 wickets,200,won,1st,Australia,Faridabad,10/29/2003,Stephen Fleming (NZ)
+India,lost,8 wickets,209,won,1st,Sri Lanka,Dambulla,8/22/2010,
+Sri Lanka,won,8 wickets,209,lost,2nd,India,Dambulla,8/22/2010,
+England,lost,8 wickets,226,won,1st,New Zealand,Wellington,2/20/2015,Brendon McCullum (NZ)
+New Zealand,won,8 wickets,226,lost,2nd,England,Wellington,2/20/2015,Brendon McCullum (NZ)
+Australia,lost,80 runs,0,lost,2nd,South Africa,Port Elizabeth,10/23/2011,
+Australia,won,80 runs,0,lost,1st,Sri Lanka,Adelaide,1/24/1999,
+Australia,won,80 runs,0,won,1st,South Africa,Melbourne (Docklands),2/3/2006,
+England,lost,80 runs,0,lost,2nd,South Africa,Southampton,8/28/2012,
+India,lost,80 runs,0,lost,2nd,South Africa,Port Elizabeth,11/29/2006,
+India,lost,80 runs,0,lost,2nd,South Africa,Sharjah,4/14/1996,
+India,won,80 runs,0,lost,1st,Sri Lanka,Nagpur,3/22/1999,
+India,won,80 runs,0,won,1st,West Indies,Chennai,3/20/2011,
+South Africa,lost,80 runs,0,lost,2nd,Australia,Melbourne (Docklands),2/3/2006,
+South Africa,won,80 runs,0,won,1st,Australia,Port Elizabeth,10/23/2011,
+South Africa,won,80 runs,0,won,1st,England,Southampton,8/28/2012,
+South Africa,won,80 runs,0,won,1st,India,Port Elizabeth,11/29/2006,
+South Africa,won,80 runs,0,won,1st,India,Sharjah,4/14/1996,
+Sri Lanka,lost,80 runs,0,won,2nd,Australia,Adelaide,1/24/1999,
+Sri Lanka,lost,80 runs,0,won,2nd,India,Nagpur,3/22/1999,
+West Indies,lost,80 runs,0,lost,2nd,India,Chennai,3/20/2011,
+Australia,won,81 runs,0,won,1st,Pakistan,Sydney,1/19/2000,
+England,won,81 runs,0,lost,1st,Sri Lanka,The Oval,5/22/2014,
+India,won,81 runs,0,lost,1st,Sri Lanka,Port of Spain,7/9/2013,
+India,won,81 runs,0,lost,1st,Sri Lanka,Sharjah,11/9/1998,
+India,won,81 runs,0,won,1st,Sri Lanka,Dambulla,6/24/2010,
+India,won,81 runs,0,won,2nd,West Indies,Rajkot,11/12/2002,
+New Zealand,lost,81 runs,0,lost,2nd,Sri Lanka,Kingston,4/24/2007,Stephen Fleming (NZ)
+New Zealand,won,81 runs,0,won,1st,West Indies,Wellington,2/18/2006,Stephen Fleming (NZ)
+Pakistan,lost,81 runs,0,lost,2nd,Australia,Sydney,1/19/2000,
+Sri Lanka,lost,81 runs,0,lost,2nd,India,Dambulla,6/24/2010,
+Sri Lanka,lost,81 runs,0,won,2nd,England,The Oval,5/22/2014,
+Sri Lanka,lost,81 runs,0,won,2nd,India,Port of Spain,7/9/2013,
+Sri Lanka,lost,81 runs,0,won,2nd,India,Sharjah,11/9/1998,
+Sri Lanka,won,81 runs,0,won,1st,New Zealand,Kingston,4/24/2007,Stephen Fleming (NZ)
+West Indies,lost,81 runs,0,lost,1st,India,Rajkot,11/12/2002,
+West Indies,lost,81 runs,0,lost,2nd,New Zealand,Wellington,2/18/2006,Stephen Fleming (NZ)
+Australia,won,82 runs,0,lost,1st,Pakistan,Johannesburg,2/11/2003,
+England,lost,82 runs,0,lost,2nd,India,Durban,2/26/2003,
+India,won,82 runs,0,won,1st,England,Durban,2/26/2003,
+Pakistan,lost,82 runs,0,won,2nd,Australia,Johannesburg,2/11/2003,
+Pakistan,won,82 runs,0,lost,1st,Sri Lanka,Nairobi (Gym),10/4/1996,
+South Africa,won,82 runs,0,won,1st,Sri Lanka,Hambantota,7/12/2014,
+Sri Lanka,lost,82 runs,0,lost,2nd,South Africa,Hambantota,7/12/2014,
+Sri Lanka,lost,82 runs,0,won,2nd,Pakistan,Nairobi (Gym),10/4/1996,
+Australia,won,83 runs,0,lost,1st,South Africa,Basseterre,3/24/2007,
+Australia,won,83 runs,0,won,1st,Sri Lanka,Perth,1/12/1996,
+South Africa,lost,83 runs,0,won,2nd,Australia,Basseterre,3/24/2007,
+Sri Lanka,lost,83 runs,0,lost,2nd,Australia,Perth,1/12/1996,
+Australia,won,84 runs,0,lost,1st,India,Kochi,10/2/2007,
+Australia,won,84 runs,0,lost,1st,West Indies,Kingstown,6/24/2008,
+Australia,won,84 runs,0,won,1st,Sri Lanka,Dambulla,2/20/2004,
+England,won,84 runs,0,won,1st,Pakistan,Dubai (DSC),11/20/2015,
+India,lost,84 runs,0,lost,2nd,New Zealand,Colombo (RPS),7/20/2001,Stephen Fleming (NZ)
+India,lost,84 runs,0,won,2nd,Australia,Kochi,10/2/2007,
+India,won,84 runs,0,lost,2nd,New Zealand,Hamilton,3/11/2009,Daniel Vettori (NZ)
+New Zealand,lost,84 runs,0,won,1st,India,Hamilton,3/11/2009,Daniel Vettori (NZ)
+New Zealand,won,84 runs,0,won,1st,India,Colombo (RPS),7/20/2001,Stephen Fleming (NZ)
+Pakistan,lost,84 runs,0,lost,2nd,England,Dubai (DSC),11/20/2015,
+Sri Lanka,lost,84 runs,0,lost,2nd,Australia,Dambulla,2/20/2004,
+West Indies,lost,84 runs,0,won,2nd,Australia,Kingstown,6/24/2008,
+India,lost,85 runs,0,won,2nd,Pakistan,Kolkata,1/3/2013,
+Pakistan,lost,85 runs,0,lost,2nd,Sri Lanka,Kolkata,5/27/1997,
+Pakistan,won,85 runs,0,lost,1st,India,Kolkata,1/3/2013,
+Sri Lanka,won,85 runs,0,won,1st,Pakistan,Kolkata,5/27/1997,
+Australia,won,86 runs,0,lost,1st,Pakistan,Karachi,11/6/1998,
+Australia,won,86 runs,0,won,1st,New Zealand,Auckland,2/26/2005,Stephen Fleming (NZ)
+England,lost,86 runs,0,lost,2nd,New Zealand,Southampton,6/2/2013,Brendon McCullum (NZ)
+New Zealand,lost,86 runs,0,lost,2nd,Australia,Auckland,2/26/2005,Stephen Fleming (NZ)
+New Zealand,won,86 runs,0,won,1st,England,Southampton,6/2/2013,Brendon McCullum (NZ)
+Pakistan,lost,86 runs,0,won,2nd,Australia,Karachi,11/6/1998,
+South Africa,won,86 runs,0,won,1st,West Indies,Cape Town,1/25/2008,
+West Indies,lost,86 runs,0,lost,2nd,South Africa,Cape Town,1/25/2008,
+Australia,won,87 runs,0,won,1st,India,Sydney,2/26/2012,
+England,lost,87 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),12/16/2014,
+India,lost,87 runs,0,lost,2nd,Australia,Sydney,2/26/2012,
+India,lost,87 runs,0,won,2nd,New Zealand,Wellington,1/31/2014,Brendon McCullum (NZ)
+India,won,87 runs,0,won,1st,Pakistan,Kochi,4/2/2005,
+New Zealand,lost,87 runs,0,won,2nd,Sri Lanka,Colombo (SSC),7/5/1998,Stephen Fleming (NZ)
+New Zealand,won,87 runs,0,lost,1st,India,Wellington,1/31/2014,Brendon McCullum (NZ)
+New Zealand,won,87 runs,0,lost,1st,South Africa,Mumbai (BS),10/16/2006,Stephen Fleming (NZ)
+Pakistan,lost,87 runs,0,lost,2nd,India,Kochi,4/2/2005,
+South Africa,lost,87 runs,0,lost,2nd,Sri Lanka,Pallekele,7/9/2014,
+South Africa,lost,87 runs,0,won,2nd,New Zealand,Mumbai (BS),10/16/2006,Stephen Fleming (NZ)
+Sri Lanka,won,87 runs,0,lost,1st,New Zealand,Colombo (SSC),7/5/1998,Stephen Fleming (NZ)
+Sri Lanka,won,87 runs,0,won,1st,England,Colombo (RPS),12/16/2014,
+Sri Lanka,won,87 runs,0,won,1st,South Africa,Pallekele,7/9/2014,
+Australia,won,88 runs,0,lost,1st,England,Manchester,9/8/2013,
+England,lost,88 runs,0,won,2nd,Australia,Manchester,9/8/2013,
+India,won,88 runs,0,lost,1st,West Indies,Toronto,9/14/1999,
+New Zealand,won,88 runs,0,lost,1st,West Indies,Basseterre,7/11/2012,
+Pakistan,won,88 runs,0,won,1st,Sri Lanka,Sharjah,10/22/1999,
+Sri Lanka,lost,88 runs,0,lost,2nd,Pakistan,Sharjah,10/22/1999,
+West Indies,lost,88 runs,0,won,2nd,India,Toronto,9/14/1999,
+West Indies,lost,88 runs,0,won,2nd,New Zealand,Basseterre,7/11/2012,
+Australia,won,89 runs,0,won,1st,England,Melbourne,12/15/2002,
+England,lost,89 runs,0,lost,2nd,Australia,Melbourne,12/15/2002,
+South Africa,won,89 runs,0,lost,1st,Sri Lanka,Northampton,5/19/1999,
+South Africa,won,89 runs,0,won,1st,West Indies,Cape Town,2/2/1999,
+Sri Lanka,lost,89 runs,0,won,2nd,South Africa,Northampton,5/19/1999,
+West Indies,lost,89 runs,0,lost,2nd,South Africa,Cape Town,2/2/1999,
+Australia,lost,9 runs,0,lost,2nd,India,Brisbane,3/4/2008,
+Australia,lost,9 runs,0,lost,2nd,Sri Lanka,Melbourne,3/2/2012,
+Australia,won,9 runs,0,lost,1st,Sri Lanka,Sydney,1/20/1996,
+England,lost,9 runs,0,lost,2nd,India,Bristol,8/24/2007,
+England,lost,9 runs,0,lost,2nd,India,Sharjah,4/11/1999,
+England,lost,9 runs,0,won,2nd,New Zealand,Auckland,3/2/1997,Lee Germon (NZ)
+England,won,9 runs,0,won,1st,India,Rajkot,1/11/2013,
+India,lost,9 runs,0,lost,2nd,England,Rajkot,1/11/2013,
+India,lost,9 runs,0,won,2nd,Sri Lanka,Colombo (SSC),8/24/1997,
+India,won,9 runs,0,won,1st,Australia,Brisbane,3/4/2008,
+India,won,9 runs,0,won,1st,England,Bristol,8/24/2007,
+India,won,9 runs,0,won,1st,England,Sharjah,4/11/1999,
+New Zealand,won,9 runs,0,lost,1st,England,Auckland,3/2/1997,Lee Germon (NZ)
+New Zealand,won,9 runs,0,lost,1st,Sri Lanka,Dambulla,5/19/2003,Stephen Fleming (NZ)
+New Zealand,won,9 runs,0,won,1st,West Indies,Port of Spain,6/12/2002,Stephen Fleming (NZ)
+New Zealand,won,9 runs,0,won,2nd,West Indies,Napier,1/13/2009,Daniel Vettori (NZ)
+Pakistan,lost,9 runs,0,lost,2nd,Sri Lanka,Sharjah,4/12/2002,
+Pakistan,lost,9 runs,0,won,2nd,South Africa,Lahore,11/2/1997,
+Pakistan,won,9 runs,0,won,1st,Sri Lanka,Jamshedpur,3/19/1999,
+South Africa,won,9 runs,0,lost,1st,Pakistan,Lahore,11/2/1997,
+South Africa,won,9 runs,0,won,1st,Sri Lanka,Adelaide,1/24/2006,
+Sri Lanka,lost,9 runs,0,lost,2nd,Pakistan,Jamshedpur,3/19/1999,
+Sri Lanka,lost,9 runs,0,lost,2nd,South Africa,Adelaide,1/24/2006,
+Sri Lanka,lost,9 runs,0,won,2nd,Australia,Sydney,1/20/1996,
+Sri Lanka,lost,9 runs,0,won,2nd,New Zealand,Dambulla,5/19/2003,Stephen Fleming (NZ)
+Sri Lanka,won,9 runs,0,lost,1st,India,Colombo (SSC),8/24/1997,
+Sri Lanka,won,9 runs,0,won,1st,Australia,Melbourne,3/2/2012,
+Sri Lanka,won,9 runs,0,won,1st,Pakistan,Sharjah,4/12/2002,
+West Indies,lost,9 runs,0,lost,1st,New Zealand,Napier,1/13/2009,Daniel Vettori (NZ)
+West Indies,lost,9 runs,0,lost,2nd,New Zealand,Port of Spain,6/12/2002,Stephen Fleming (NZ)
+England,won,9 wickets,9,won,2nd,West Indies,Bridgetown,3/29/2009,
+West Indies,lost,9 wickets,9,lost,1st,England,Bridgetown,3/29/2009,
+New Zealand,won,9 wickets,13,lost,2nd,South Africa,Johannesburg,2/16/2003,Stephen Fleming (NZ)
+South Africa,lost,9 wickets,13,won,1st,New Zealand,Johannesburg,2/16/2003,Stephen Fleming (NZ)
+New Zealand,lost,9 wickets,15,won,1st,Pakistan,Manchester,6/16/1999,Stephen Fleming (NZ)
+Pakistan,won,9 wickets,15,lost,2nd,New Zealand,Manchester,6/16/1999,Stephen Fleming (NZ)
+England,lost,9 wickets,16,won,1st,Sri Lanka,Wellington,3/1/2015,
+Sri Lanka,won,9 wickets,16,lost,2nd,England,Wellington,3/1/2015,
+Australia,lost,9 wickets,24,lost,1st,England,Leeds,7/7/2005,
+England,won,9 wickets,24,won,2nd,Australia,Leeds,7/7/2005,
+Australia,won,9 wickets,27,lost,2nd,Sri Lanka,Brisbane,2/14/2006,
+Sri Lanka,lost,9 wickets,27,won,1st,Australia,Brisbane,2/14/2006,
+India,lost,9 wickets,34,won,1st,Sri Lanka,Colombo (RPS),8/28/1996,
+Sri Lanka,won,9 wickets,34,lost,2nd,India,Colombo (RPS),8/28/1996,
+Australia,won,9 wickets,38,lost,2nd,West Indies,Brisbane,1/14/2001,
+West Indies,lost,9 wickets,38,won,1st,Australia,Brisbane,1/14/2001,
+Australia,lost,9 wickets,39,won,1st,India,Jaipur,10/16/2013,
+Australia,lost,9 wickets,39,won,1st,West Indies,St George's,6/1/2003,
+India,won,9 wickets,39,lost,2nd,Australia,Jaipur,10/16/2013,
+West Indies,won,9 wickets,39,lost,2nd,Australia,St George's,6/1/2003,
+Pakistan,won,9 wickets,40,lost,2nd,Sri Lanka,Nairobi (Gym),10/8/2000,
+Sri Lanka,lost,9 wickets,40,won,1st,Pakistan,Nairobi (Gym),10/8/2000,
+Pakistan,lost,9 wickets,48,won,1st,South Africa,Paarl,12/16/2002,
+South Africa,won,9 wickets,48,lost,2nd,Pakistan,Paarl,12/16/2002,
+Australia,won,9 wickets,49,lost,2nd,England,Centurion,10/2/2009,
+England,lost,9 wickets,49,won,1st,Australia,Centurion,10/2/2009,
+New Zealand,lost,9 wickets,52,lost,1st,West Indies,Kingston,7/5/2012,
+West Indies,won,9 wickets,52,won,2nd,New Zealand,Kingston,7/5/2012,
+England,won,9 wickets,63,lost,2nd,South Africa,Bloemfontein,1/23/2000,
+India,won,9 wickets,63,won,2nd,New Zealand,Vadodara,12/4/2010,Daniel Vettori (NZ)
+New Zealand,lost,9 wickets,63,lost,1st,India,Vadodara,12/4/2010,Daniel Vettori (NZ)
+South Africa,lost,9 wickets,63,won,1st,England,Bloemfontein,1/23/2000,
+Australia,won,9 wickets,64,lost,2nd,England,Melbourne,1/15/1999,
+England,lost,9 wickets,64,won,1st,Australia,Melbourne,1/15/1999,
+England,won,9 wickets,76,lost,2nd,Pakistan,Dubai (DSC),2/18/2012,
+Pakistan,lost,9 wickets,76,won,1st,England,Dubai (DSC),2/18/2012,
+Australia,won,9 wickets,82,won,2nd,Pakistan,Sydney,1/23/2005,
+Pakistan,lost,9 wickets,82,lost,1st,Australia,Sydney,1/23/2005,
+Australia,won,9 wickets,93,lost,2nd,Sri Lanka,Melbourne,1/21/2003,
+Sri Lanka,lost,9 wickets,93,won,1st,Australia,Melbourne,1/21/2003,
+New Zealand,lost,9 wickets,103,lost,1st,Sri Lanka,Auckland,2/6/2001,Stephen Fleming (NZ)
+Sri Lanka,won,9 wickets,103,won,2nd,New Zealand,Auckland,2/6/2001,Stephen Fleming (NZ)
+India,lost,9 wickets,112,lost,1st,South Africa,Centurion,12/3/2006,
+South Africa,won,9 wickets,112,won,2nd,India,Centurion,12/3/2006,
+England,lost,9 wickets,117,lost,1st,India,Birmingham,9/2/2014,
+India,won,9 wickets,117,won,2nd,England,Birmingham,9/2/2014,
+Pakistan,lost,9 wickets,130,won,1st,South Africa,Johannesburg,2/14/2007,
+South Africa,won,9 wickets,130,lost,2nd,Pakistan,Johannesburg,2/14/2007,
+Sri Lanka,won,9 wickets,132,lost,2nd,West Indies,Sharjah,10/17/1999,
+West Indies,lost,9 wickets,132,won,1st,Sri Lanka,Sharjah,10/17/1999,
+Pakistan,lost,9 wickets,134,lost,1st,South Africa,Cape Town,4/23/1998,
+South Africa,won,9 wickets,134,won,2nd,Pakistan,Cape Town,4/23/1998,
+England,won,9 wickets,135,lost,2nd,India,Brisbane,1/20/2015,
+India,lost,9 wickets,135,won,1st,England,Brisbane,1/20/2015,
+India,lost,9 wickets,136,lost,1st,Pakistan,Lahore,10/2/1997,
+Pakistan,won,9 wickets,136,won,2nd,India,Lahore,10/2/1997,
+Australia,won,9 wickets,141,lost,2nd,Pakistan,Lord's,6/23/2001,
+Pakistan,lost,9 wickets,141,won,1st,Australia,Lord's,6/23/2001,
+Australia,won,9 wickets,145,lost,2nd,India,Vadodara,10/11/2007,
+India,lost,9 wickets,145,won,1st,Australia,Vadodara,10/11/2007,
+South Africa,won,9 wickets,152,lost,2nd,West Indies,East London,1/21/2015,
+West Indies,lost,9 wickets,152,won,1st,South Africa,East London,1/21/2015,
+Australia,won,9 wickets,153,lost,2nd,England,Adelaide,1/26/2007,
+England,lost,9 wickets,153,won,1st,Australia,Adelaide,1/26/2007,
+Australia,won,9 wickets,166,lost,2nd,India,Centurion,2/15/2003,
+India,lost,9 wickets,166,won,1st,Australia,Centurion,2/15/2003,
+India,lost,9 wickets,181,won,1st,Sri Lanka,Hambantota,7/24/2012,
+Sri Lanka,won,9 wickets,181,lost,2nd,India,Hambantota,7/24/2012,
+England,lost,9 wickets,184,won,1st,South Africa,Bridgetown,4/17/2007,
+South Africa,won,9 wickets,184,lost,2nd,England,Bridgetown,4/17/2007,
+Australia,won,9 wickets,185,lost,2nd,Pakistan,Nairobi (Gym),9/4/2002,
+Pakistan,lost,9 wickets,185,won,1st,Australia,Nairobi (Gym),9/4/2002,
+South Africa,won,9 wickets,192,lost,2nd,Sri Lanka,Sydney,3/18/2015,
+Sri Lanka,lost,9 wickets,192,won,1st,South Africa,Sydney,3/18/2015,
+New Zealand,won,9 wickets,196,lost,2nd,Pakistan,Wellington,1/22/2011,Daniel Vettori (NZ)
+Pakistan,lost,9 wickets,196,won,1st,New Zealand,Wellington,1/22/2011,Daniel Vettori (NZ)
+Sri Lanka,won,9 wickets,220,lost,2nd,West Indies,Mumbai (BS),10/14/2006,
+West Indies,lost,9 wickets,220,won,1st,Sri Lanka,Mumbai (BS),10/14/2006,
+Australia,won,9 wickets,244,lost,2nd,West Indies,Perth,2/1/2013,
+West Indies,lost,9 wickets,244,won,1st,Australia,Perth,2/1/2013,
+England,lost,90 runs,0,lost,2nd,New Zealand,Adelaide,1/23/2007,Stephen Fleming (NZ)
+England,lost,90 runs,0,lost,2nd,Pakistan,Sharjah,4/7/1999,
+England,lost,90 runs,0,lost,2nd,Sri Lanka,Pallekele,12/13/2014,
+India,lost,90 runs,0,lost,2nd,South Africa,Ahmedabad,2/27/2010,
+New Zealand,won,90 runs,0,won,1st,England,Adelaide,1/23/2007,Stephen Fleming (NZ)
+Pakistan,won,90 runs,0,won,1st,England,Sharjah,4/7/1999,
+South Africa,won,90 runs,0,won,1st,India,Ahmedabad,2/27/2010,
+Sri Lanka,won,90 runs,0,won,1st,England,Pallekele,12/13/2014,
+Australia,lost,91 runs,0,lost,2nd,Pakistan,Brisbane,6/19/2002,
+New Zealand,won,91 runs,0,lost,1st,West Indies,Napier,3/1/2006,Stephen Fleming (NZ)
+Pakistan,won,91 runs,0,won,1st,Australia,Brisbane,6/19/2002,
+West Indies,lost,91 runs,0,won,2nd,New Zealand,Napier,3/1/2006,Stephen Fleming (NZ)
+Australia,lost,92 runs,0,lost,2nd,England,Sydney,2/2/2007,
+England,won,92 runs,0,won,1st,Australia,Sydney,2/2/2007,
+South Africa,won,92 runs,0,lost,1st,Sri Lanka,Dhaka,10/30/1998,
+Sri Lanka,lost,92 runs,0,won,2nd,South Africa,Dhaka,10/30/1998,
+Australia,lost,93 runs,0,lost,2nd,England,Manchester,9/8/2015,
+Australia,won,93 runs,0,lost,1st,South Africa,Centurion,10/19/2011,
+Australia,won,93 runs,0,won,1st,India,Visakhapatnam,4/3/2001,
+Australia,won,93 runs,0,won,1st,Pakistan,Sharjah,10/7/2014,
+England,lost,93 runs,0,lost,2nd,West Indies,Nottingham,7/7/2007,
+England,won,93 runs,0,won,1st,Australia,Manchester,9/8/2015,
+India,lost,93 runs,0,lost,2nd,Australia,Visakhapatnam,4/3/2001,
+New Zealand,lost,93 runs,0,lost,2nd,South Africa,Adelaide,1/27/2002,Stephen Fleming (NZ)
+Pakistan,lost,93 runs,0,lost,2nd,Australia,Sharjah,10/7/2014,
+Pakistan,lost,93 runs,0,lost,2nd,South Africa,Singapore,8/27/2000,
+South Africa,lost,93 runs,0,lost,2nd,Sri Lanka,Tangier,8/15/2002,
+South Africa,lost,93 runs,0,won,2nd,Australia,Centurion,10/19/2011,
+South Africa,won,93 runs,0,won,1st,New Zealand,Adelaide,1/27/2002,Stephen Fleming (NZ)
+South Africa,won,93 runs,0,won,1st,Pakistan,Singapore,8/27/2000,
+Sri Lanka,won,93 runs,0,won,1st,South Africa,Tangier,8/15/2002,
+West Indies,won,93 runs,0,won,1st,England,Nottingham,7/7/2007,
+Australia,won,94 runs,0,lost,1st,South Africa,Melbourne (Docklands),8/16/2000,
+South Africa,lost,94 runs,0,won,2nd,Australia,Melbourne (Docklands),8/16/2000,
+South Africa,lost,94 runs,0,won,2nd,Sri Lanka,Brisbane,1/17/2006,
+Sri Lanka,won,94 runs,0,lost,1st,South Africa,Brisbane,1/17/2006,
+Australia,won,95 runs,0,won,1st,India,Sydney,3/26/2015,
+England,lost,95 runs,0,won,2nd,India,Kolkata,10/25/2011,
+England,won,95 runs,0,won,1st,Pakistan,Abu Dhabi,11/13/2015,
+England,won,95 runs,0,won,1st,Sri Lanka,Perth,12/20/2002,
+India,lost,95 runs,0,lost,2nd,Australia,Sydney,3/26/2015,
+India,won,95 runs,0,lost,1st,England,Kolkata,10/25/2011,
+India,won,95 runs,0,won,1st,South Africa,Nairobi (Gym),10/13/2000,
+Pakistan,lost,95 runs,0,lost,2nd,England,Abu Dhabi,11/13/2015,
+South Africa,lost,95 runs,0,lost,2nd,India,Nairobi (Gym),10/13/2000,
+South Africa,won,95 runs,0,won,1st,Sri Lanka,East London,12/17/2000,
+Sri Lanka,lost,95 runs,0,lost,2nd,England,Perth,12/20/2002,
+Sri Lanka,lost,95 runs,0,lost,2nd,South Africa,East London,12/17/2000,
+Australia,won,96 runs,0,lost,1st,New Zealand,Port Elizabeth,3/11/2003,Stephen Fleming (NZ)
+Australia,won,96 runs,0,won,1st,Sri Lanka,Centurion,3/7/2003,
+New Zealand,lost,96 runs,0,won,2nd,Australia,Port Elizabeth,3/11/2003,Stephen Fleming (NZ)
+Pakistan,lost,96 runs,0,lost,2nd,West Indies,Kingstown,4/12/2000,
+Sri Lanka,lost,96 runs,0,lost,2nd,Australia,Centurion,3/7/2003,
+West Indies,won,96 runs,0,won,1st,Pakistan,Kingstown,4/12/2000,
+India,lost,97 runs,0,won,2nd,Pakistan,Toronto,9/21/1996,
+New Zealand,lost,97 runs,0,lost,2nd,Sri Lanka,Colombo (RPS),9/8/2009,Daniel Vettori (NZ)
+Pakistan,won,97 runs,0,lost,1st,India,Toronto,9/21/1996,
+Sri Lanka,won,97 runs,0,won,1st,New Zealand,Colombo (RPS),9/8/2009,Daniel Vettori (NZ)
+India,lost,98 runs,0,lost,2nd,Pakistan,Sharjah,3/26/2000,
+New Zealand,won,98 runs,0,lost,1st,Sri Lanka,Christchurch,2/14/2015,Brendon McCullum (NZ)
+Pakistan,won,98 runs,0,won,1st,India,Sharjah,3/26/2000,
+Pakistan,won,98 runs,0,won,1st,Sri Lanka,Abu Dhabi,5/20/2007,
+Sri Lanka,lost,98 runs,0,lost,2nd,Pakistan,Abu Dhabi,5/20/2007,
+Sri Lanka,lost,98 runs,0,won,2nd,New Zealand,Christchurch,2/14/2015,Brendon McCullum (NZ)
+Australia,lost,99 runs,0,won,2nd,India,Nagpur,10/28/2009,
+India,won,99 runs,0,lost,1st,Australia,Nagpur,10/28/2009,
+South Africa,won,99 runs,0,lost,1st,West Indies,Port Elizabeth,1/30/1999,
+South Africa,won,99 runs,0,won,1st,Sri Lanka,Cape Town,1/11/2001,
+Sri Lanka,lost,99 runs,0,lost,2nd,South Africa,Cape Town,1/11/2001,
+West Indies,lost,99 runs,0,won,2nd,South Africa,Port Elizabeth,1/30/1999,
+England,lost,,0,lost,1st,Pakistan,Leeds,6/17/2001,
+India,lost,,0,won,2nd,Sri Lanka,Kolkata,3/13/1996,
+Pakistan,won,,0,won,2nd,England,Leeds,6/17/2001,
+Sri Lanka,won,,0,lost,1st,India,Kolkata,3/13/1996,

--- a/web/data/cricket-odi-2.csv
+++ b/web/data/cricket-odi-2.csv
@@ -3209,4 +3209,3 @@ New Zealand,won,10 wickets,250,lost,2nd,Sri Lanka,Christchurch,28-Dec-15
 Sri Lanka,lost,10 wickets,250,won,1st,New Zealand,Christchurch,28-Dec-15
 Sri Lanka,won,8 wickets,22,lost,2nd,New Zealand,Nelson,31-Dec-15
 New Zealand,lost,8 wickets,22,won,1st,Sri Lanka,Nelson,31-Dec-15
-,,,0,,,,,

--- a/web/js/cricket.js
+++ b/web/js/cricket.js
@@ -434,7 +434,7 @@ function change_result_view2() {
 
 //Queueing defer ensures that all our datasets get loaded before any work is done
 
-queue()
+this.queue()
     .defer(d3.csv, "data/cricket-odi.csv")
     // .defer(d3.csv, "import-data.csv") //change name here to load more than 1 file
     .await(showCharts);

--- a/web/js/cricket.js
+++ b/web/js/cricket.js
@@ -52,7 +52,7 @@ $( window ).resize(function() {
 });
 
 function cleanup(d) {
-  
+
   d.Year = d.Date.slice(-2);
   d.Year = d.Year > 16 ? 1900+parseInt(d.Year) : 2000+parseInt(d.Year);
   d.Value = 1;
@@ -63,18 +63,18 @@ function cleanup(d) {
   return d;
 }
 
-function isOdd(num) { 
+function isOdd(num) {
   return num % 2;
 }
 
-function capitalizeFirst(string) { 
-  return string.charAt(0).toUpperCase() + string.slice(1); 
+function capitalizeFirst(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 //Queueing defer ensures that all our datasets get loaded before any work is done
 
 queue()
-    .defer(d3.csv, "data/cricket-odi.csv")
+    .defer(d3.csv, "data/cricket-captains.csv")
     // .defer(d3.csv, "import-data.csv") //change name here to load more than 1 file
     .await(showCharts);
 
@@ -102,14 +102,14 @@ function showCharts(err, data) {
       }
     }
   }
-  
+
   resultByYear = configureableReduce("Result", "Value", {
     "won": 0,
     "lost": 0,
     "tied": 0
   });
-  
-    
+
+
   //---------------------------------FILTERS-----------------------------------------
   ndx = crossfilter(_data);
   ndx2 = crossfilter(_data);
@@ -129,20 +129,20 @@ function showCharts(err, data) {
   resultStatus = ndx.dimension(function(d) {return d.resultStatus});
   resultStatus2 = ndx.dimension(function(d) {return d.resultStatus});
 
-  year_group = year.group().reduceSum(function(d){return d.Value}); 
-  year_group2 = year2.group().reduceSum(function(d){return d.Value}); 
+  year_group = year.group().reduceSum(function(d){return d.Value});
+  year_group2 = year2.group().reduceSum(function(d){return d.Value});
 
-  opposition_group = opposition.group().reduceSum(function(d){return d.Value}); 
+  opposition_group = opposition.group().reduceSum(function(d){return d.Value});
   opposition_group2 = opposition2.group().reduceSum(function(d){return d.Value});
 
   team_group = team.group().reduceSum(function(d){return d.Value});
-  team_group2 = team2.group().reduceSum(function(d){return d.Value}); 
+  team_group2 = team2.group().reduceSum(function(d){return d.Value});
 
   result_pie_group = result.group().reduceSum(function(d){return d.Value});
   result_pie_group2 = result2.group().reduceSum(function(d){return d.Value});
 
 //  result_year_group = year.group().reduce(resultByYear.add, resultByYear.remove, resultByYear.init);
-  
+
   result_year_group = year.group().reduce(
     function(p, v) { // add
       p[v.Result] = p[v.Result] || [];
@@ -159,7 +159,7 @@ function showCharts(err, data) {
       return {};
     }
   );
-    
+
   result_year_group2 = year2.group().reduce(
     function(p, v) { // add
       p[v.Result] = p[v.Result] || [];
@@ -176,17 +176,17 @@ function showCharts(err, data) {
       return {};
     }
   );
-  
+
   result_group = resultStatus.group().reduceSum(function(d){
     if (d.Result != 'tied') return d.Value;
     else return 0;
   });
-  
+
   result_group2 = resultStatus2.group().reduceSum(function(d){
     if (d.Result != 'tied') return d.Value;
     else return 0;
   });
-  
+
   year_chart = dc.rowChart('#year')
     .dimension(year)
     .group(year_group)
@@ -197,10 +197,10 @@ function showCharts(err, data) {
     .ordering(function(d){ return -d.key })
 //    .x(d3.scale.linear().domain([-25, 25]))
     .elasticX(true);
-  
+
   year_chart.xAxis().ticks(10).tickFormat(d3.format("g"));
   grey_undefined(year_chart);
-  
+
   year_bar_chart = dc.barChart('#year-bar')
       .dimension(year)
       .group(year_group)
@@ -213,10 +213,10 @@ function showCharts(err, data) {
       .brushOn(true)
       .elasticY(true)
       .elasticX(true);
-  
+
   year_bar_chart.xAxis().ticks(5).tickFormat(d3.format("g"));
   grey_undefined(year_bar_chart);
-    
+
   opposition_chart = dc.rowChart('#opposition')
     .dimension(opposition)
     .group(opposition_group)
@@ -238,7 +238,7 @@ function showCharts(err, data) {
       var title = d.key + " \nTotal Games Against Team A: " + d.value;
       return title;
     });
-  
+
   opposition_chart._onClick = function(d) {
       if($.inArray(d.key, team_chart.filters()) == 0) return;
       var filter = opposition_chart.keyAccessor()(d);
@@ -247,10 +247,10 @@ function showCharts(err, data) {
             opposition_chart.redrawGroup();
         });
    }
-  
+
   opposition_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(opposition_chart);
-  
+
   opposition_chart2 = dc.rowChart('#opposition2')
     .dimension(opposition2)
     .group(opposition_group2)
@@ -272,7 +272,7 @@ function showCharts(err, data) {
       var title = d.key + " \nTotal Games Against Team B: " + d.value;
       return title;
     });
-  
+
   opposition_chart2._onClick = function(d) {
       if($.inArray(d.key, team_chart2.filters()) == 0) return;
       var filter = opposition_chart2.keyAccessor()(d);
@@ -281,12 +281,12 @@ function showCharts(err, data) {
             opposition_chart2.redrawGroup();
         });
    }
-  
+
   opposition_chart2.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(opposition_chart2);
-  
-  
-    
+
+
+
   team_chart = dc.rowChart('#team')
     .dimension(team)
     .group(team_group)
@@ -307,7 +307,7 @@ function showCharts(err, data) {
       var title = d.key + " \nTotal Games Against Opposition(s): " + d.value;
       return title;
     });
-  
+
   team_chart._onClick = function(d) {
       dc.events.trigger(() => {
         team_chart.replaceFilter(d.key);
@@ -316,10 +316,10 @@ function showCharts(err, data) {
       hideButton('#teamA');
       change_title();
    };
-  
+
   team_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(team_chart);
-  
+
   team_chart2 = dc.rowChart('#team2')
     .dimension(team2)
     .group(team_group2)
@@ -340,7 +340,7 @@ function showCharts(err, data) {
       var title = d.key + " \nTotal Games Against Opposition(s): " + d.value;
       return title;
     });
-  
+
   team_chart2._onClick = function(d) {
       dc.events.trigger(() => {
         team_chart2.replaceFilter(d.key);
@@ -349,10 +349,10 @@ function showCharts(err, data) {
       hideButton('#teamB');
       change_title();
    };
-  
+
   team_chart2.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(team_chart2);
-    
+
   result_chart = dc.pieChart('#result')
     .dimension(result)
     .group(result_pie_group)
@@ -383,7 +383,7 @@ function showCharts(err, data) {
       else if (d.key == "lost") return "lost";
       return "tied";
     });
-  
+
   result_chart2 = dc.pieChart('#result2')
     .dimension(result2)
     .group(result_pie_group2)
@@ -414,7 +414,7 @@ function showCharts(err, data) {
       else if (d.key == "lost") return "lost";
       return "tied";
     });
-  
+
   var all = ndx.groupAll();
   data_count_chart = dc.dataCount('#data_count')
     .dimension(ndx)
@@ -424,7 +424,7 @@ function showCharts(err, data) {
             ' | <a class=\'reset\' href=\'javascript: team_chart.replaceFilter("Australia"); hideButton("#teamA"); opposition_chart.filterAll(); result_chart.filterAll(); first_time = true; perc_view = true; change_result_view(); change_title(); dc.redrawAll(); \'\'>Reset All</a>',
         all: '<span class=\'data-count\'>All records selected. Please click on the graph to apply filters.<span>'
     });
-  
+
   var all2 = ndx2.groupAll();
   data_count_chart2 = dc.dataCount('#data_count2')
     .dimension(ndx2)
@@ -434,9 +434,9 @@ function showCharts(err, data) {
             ' | <a class=\'reset\' href=\'javascript: team_chart2.replaceFilter("New Zealand"); hideButton("#teamB"); opposition_chart2.filterAll(); result_chart2.filterAll(); first_time = true; perc_view2 = true; change_result_view2(); change_title();\'\'>Reset All</a>',
         all: '<span class=\'data-count\'>All records selected. Please click on the graph to apply filters.<span>'
     });
-  
+
   //pyramid chart
-  
+
   team_opp_chart = dc.pyramidChart('#team_opp')
     .dimension(resultStatus)
     .group(result_group)
@@ -462,11 +462,11 @@ function showCharts(err, data) {
     // .columnLabels(['Won','Lost'])
     .columnLabelPosition([150,0])
     .transitionDuration(200);
-  
+
   team_opp_chart.xAxis().ticks(7).tickFormat(function(x) {return d3.format('s')(Math.abs(x))})
-  
+
   dc.renderAll();
-  
+
   initialize();
 };
 
@@ -477,7 +477,7 @@ function change_result_view() {
       .group(result_year_group, "won")
       .valueAccessor(function(d){return d.value["won"].length })
       .stack(result_year_group, "lost", function(d) { return d.value["lost"].length })
-      .stack(result_year_group, "tied", function(d) { 
+      .stack(result_year_group, "tied", function(d) {
         if (d.value["tied"]) return d.value["tied"].length
         else return 0;
       })
@@ -488,16 +488,16 @@ function change_result_view() {
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = 0;
         games_count = 0;
-      
+
         label_value = 0;
         if (d.value[this.layer] == undefined) label_value = 0;
         else label_value = d.value[this.layer].length;
-      
+
         output = d.key+": "+d3.format(',')(label_value)+" Game(s) ("+capitalizeFirst(this.layer)+")\n\n";
-      
+
         if (this.layer == "won"){
           if (d.value[this.layer] != undefined)
             if (d.value[this.layer].length > 1)
@@ -510,7 +510,7 @@ function change_result_view() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else if (this.layer == "lost"){
           if (d.value[this.layer] != undefined)
@@ -524,7 +524,7 @@ function change_result_view() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else {
           if (d.value[this.layer] != undefined)
@@ -538,23 +538,23 @@ function change_result_view() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            }         
+            }
         }
-  
+
         if (isNaN(v)) v = 0;
         else v = parseFloat((v*100)).toFixed(1);
-      
+
         if(d.value[this.layer] > 0){
           d3.select(".area").selectAll("circle.dot").attr("r", 10);
         }
-      
+
         if (games_count > 5) {
           games_count -= 5;
           output += "\nOthers [" + games_count + "]";
         }
-      
-        return output; 
-        
+
+        return output;
+
       })
       .brushOn(false)
       .dimension(result_year)
@@ -569,7 +569,7 @@ function change_result_view() {
       .mouseZoomable(false)
       .yAxisLabel("Games")
       .renderHorizontalGridLines(true)
-      .renderVerticalGridLines(true)  
+      .renderVerticalGridLines(true)
       .margins({top: 10, right: 50, bottom: 30, left: 50})
       .on("renderlet.result_year", function (chart) {
           //Check if labels exist
@@ -591,8 +591,8 @@ function change_result_view() {
             .text(function(d){
               return d3.select(d).data()[0].y
             })
-            .attr('x', function(d){ 
-              return +d.getAttribute('x') + (d.getAttribute('width')/2); 
+            .attr('x', function(d){
+              return +d.getAttribute('x') + (d.getAttribute('width')/2);
             })
             .attr('y', function(d){ return +d.getAttribute('y') + 15; })
             .attr('style', function(d){
@@ -621,35 +621,35 @@ function change_result_view() {
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = parseFloat(won/total);
         if (isNaN(v)) return 0;
         return parseFloat((v*100));
       })
-      .stack(result_year_group, "lost", function(d) { 
+      .stack(result_year_group, "lost", function(d) {
         won = d.value["won"].length;
         lost = d.value["lost"].length;
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = parseFloat(lost/total);
         if (isNaN(v)) return 0;
         return parseFloat((v*100).toFixed(1));
       })
-      .stack(result_year_group, "tied", function(d) { 
+      .stack(result_year_group, "tied", function(d) {
       if (d.value["tied"]) {
         won = d.value["won"].length;
         lost = d.value["lost"].length;
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-        
-        var v = parseFloat(tied/total) 
+
+        var v = parseFloat(tied/total)
         if (isNaN(v)) return 0;
         return parseFloat((v*100).toFixed(1));
       }
-      else 
+      else
         return 0
       })
       .label(function(d) { return d; })
@@ -659,16 +659,16 @@ function change_result_view() {
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = 0;
         games_count = 0;
-      
+
         label_value = 0;
         if (d.value[this.layer] == undefined) label_value = 0;
         else label_value = d.value[this.layer].length;
-      
+
         output = d.key+": "+d3.format(',')(label_value)+" Game(s) ("+capitalizeFirst(this.layer)+")\nPercentage: ";
-      
+
         if (this.layer == "won"){
           v = parseFloat((won/total));
           v = (v * 100).toFixed(1)
@@ -684,10 +684,10 @@ function change_result_view() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else if (this.layer == "lost"){
-          v = parseFloat((lost/total)); 
+          v = parseFloat((lost/total));
           v = (v * 100).toFixed(1);
           output += v + "%\n\n";
           if (d.value[this.layer] != undefined)
@@ -701,7 +701,7 @@ function change_result_view() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else {
           v = parseFloat((tied/total));
@@ -718,23 +718,23 @@ function change_result_view() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            }         
+            }
         }
-  
+
         if (isNaN(v)) v = 0;
         else v = parseFloat((v*100)).toFixed(1);
-      
+
         if(d.value[this.layer] > 0){
           d3.select(".area").selectAll("circle.dot").attr("r", 10);
         }
-      
+
         if (games_count > 5) {
           games_count -= 5;
           output += "\nOthers [" + games_count + "]";
         }
-      
-        return output; 
-        
+
+        return output;
+
       })
       .brushOn(false)
       .renderArea(true)
@@ -767,7 +767,7 @@ function change_result_view() {
                   .attr("visibility", "visible")
                   .attr("r", 5.5)
                   .style("fill", d.color);
-              })                  
+              })
               .on("mouseout", function(d) {
                 d3.select(this)
                   .attr("visibility", "visible")
@@ -796,10 +796,10 @@ function change_result_view() {
 
     result_year_chart.xAxis().ticks(10).tickFormat(d3.format("d"));
   }
-  
+
   result_year_chart.yAxis().ticks(5).tickFormat(d3.format("g"));
   grey_undefined(result_year_chart);
-  
+
   //Need to reset the filter when the view changes or else, filter lingers
   result_year_chart.filterAll();
   dc.renderAll();
@@ -814,7 +814,7 @@ function change_result_view2() {
       .group(result_year_group2, "won")
       .valueAccessor(function(d){return d.value["won"].length })
       .stack(result_year_group2, "lost", function(d) { return d.value["lost"].length })
-      .stack(result_year_group2, "tied", function(d) { 
+      .stack(result_year_group2, "tied", function(d) {
         if (d.value["tied"]) return d.value["tied"].length
         else return 0;
       })
@@ -825,16 +825,16 @@ function change_result_view2() {
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = 0;
         games_count = 0;
-      
+
         label_value = 0;
         if (d.value[this.layer] == undefined) label_value = 0;
         else label_value = d.value[this.layer].length;
-      
+
         output = d.key+": "+d3.format(',')(label_value)+" Game(s) ("+capitalizeFirst(this.layer)+")\n\n";
-      
+
         if (this.layer == "won"){
           if (d.value[this.layer] != undefined)
             if (d.value[this.layer].length > 1)
@@ -847,7 +847,7 @@ function change_result_view2() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else if (this.layer == "lost"){
           if (d.value[this.layer] != undefined)
@@ -861,7 +861,7 @@ function change_result_view2() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else {
           if (d.value[this.layer] != undefined)
@@ -875,23 +875,23 @@ function change_result_view2() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            }         
+            }
         }
-  
+
         if (isNaN(v)) v = 0;
         else v = parseFloat((v*100)).toFixed(1);
-      
+
         if(d.value[this.layer] > 0){
           d3.select(".area").selectAll("circle.dot").attr("r", 10);
         }
-      
+
         if (games_count > 5) {
           games_count -= 5;
           output += "\nOthers [" + games_count + "]";
         }
-      
-        return output; 
-        
+
+        return output;
+
       })
       .brushOn(false)
       .dimension(result_year)
@@ -906,7 +906,7 @@ function change_result_view2() {
       .mouseZoomable(false)
       .yAxisLabel("Games")
       .renderHorizontalGridLines(true)
-      .renderVerticalGridLines(true)  
+      .renderVerticalGridLines(true)
       .margins({top: 10, right: 50, bottom: 30, left: 50})
       .on("renderlet.result_year", function (chart) {
           //Check if labels exist
@@ -928,8 +928,8 @@ function change_result_view2() {
             .text(function(d){
               return d3.select(d).data()[0].y
             })
-            .attr('x', function(d){ 
-              return +d.getAttribute('x') + (d.getAttribute('width')/2); 
+            .attr('x', function(d){
+              return +d.getAttribute('x') + (d.getAttribute('width')/2);
             })
             .attr('y', function(d){ return +d.getAttribute('y') + 15; })
             .attr('style', function(d){
@@ -958,35 +958,35 @@ function change_result_view2() {
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = parseFloat(won/total);
         if (isNaN(v)) return 0;
         return parseFloat((v*100));
       })
-      .stack(result_year_group2, "lost", function(d) { 
+      .stack(result_year_group2, "lost", function(d) {
         won = d.value["won"].length;
         lost = d.value["lost"].length;
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = parseFloat(lost/total);
         if (isNaN(v)) return 0;
         return parseFloat((v*100).toFixed(1));
       })
-      .stack(result_year_group2, "tied", function(d) { 
+      .stack(result_year_group2, "tied", function(d) {
       if (d.value["tied"]) {
         won = d.value["won"].length;
         lost = d.value["lost"].length;
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-        
-        var v = parseFloat(tied/total) 
+
+        var v = parseFloat(tied/total)
         if (isNaN(v)) return 0;
         return parseFloat((v*100).toFixed(1));
       }
-      else 
+      else
         return 0
       })
       .label(function(d) { return d; })
@@ -996,16 +996,16 @@ function change_result_view2() {
         if (d.value["tied"]) tied = d.value["tied"].length
         else tied = 0;
         total = won + lost + tied;
-      
+
         var v = 0;
         games_count = 0;
-      
+
         label_value = 0;
         if (d.value[this.layer] == undefined) label_value = 0;
         else label_value = d.value[this.layer].length;
-      
+
         output = d.key+": "+d3.format(',')(label_value)+" Game(s) ("+capitalizeFirst(this.layer)+")\nPercentage: ";
-      
+
         if (this.layer == "won"){
           v = parseFloat((won/total));
           v = (v * 100).toFixed(1)
@@ -1021,10 +1021,10 @@ function change_result_view2() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else if (this.layer == "lost"){
-          v = parseFloat((lost/total)); 
+          v = parseFloat((lost/total));
           v = (v * 100).toFixed(1);
           output += v + "%\n\n";
           if (d.value[this.layer] != undefined)
@@ -1038,7 +1038,7 @@ function change_result_view2() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            } 
+            }
         }
         else {
           v = parseFloat((tied/total));
@@ -1055,23 +1055,23 @@ function change_result_view2() {
               obj = d.value[this.layer][0];
               if (obj != undefined)
                 output += "Date: " + obj.Date + " at " + obj.Ground +"\n";
-            }         
+            }
         }
-  
+
         if (isNaN(v)) v = 0;
         else v = parseFloat((v*100)).toFixed(1);
-      
+
         if(d.value[this.layer] > 0){
           d3.select(".area").selectAll("circle.dot").attr("r", 10);
         }
-      
+
         if (games_count > 5) {
           games_count -= 5;
           output += "\nOthers [" + games_count + "]";
         }
-      
-        return output; 
-        
+
+        return output;
+
       })
       .brushOn(false)
       .renderArea(true)
@@ -1104,7 +1104,7 @@ function change_result_view2() {
                   .attr("visibility", "visible")
                   .attr("r", 5.5)
                   .style("fill", d.color);
-              })                  
+              })
               .on("mouseout", function(d) {
                 d3.select(this)
                   .attr("visibility", "visible")
@@ -1133,10 +1133,10 @@ function change_result_view2() {
 
     result_year_chart2.xAxis().ticks(10).tickFormat(d3.format("d"));
   }
-  
+
   result_year_chart2.yAxis().ticks(5).tickFormat(d3.format("g"));
   grey_undefined(result_year_chart2);
-  
+
   //Need to reset the filter when the view changes or else, filter lingers
   result_year_chart2.filterAll();
   dc.renderAll();
@@ -1160,14 +1160,14 @@ function hideshow(id){
 
 function showAll() {
   var idList = ["#result_year", "#team_opp", "#result", "#team", "#opposition", "#result_year2", "#team_opp2", "#result2", "#team2", "#opposition2"]
-  
+
   for (x in idList) {
     var a = $(idList[x]);
     if (a.css('display') == "none"){
       a.toggle('show');
     }
   }
-  $('[type=checkbox]').prop('checked', true); 
+  $('[type=checkbox]').prop('checked', true);
 };
 
 function hideButton(id){
@@ -1182,13 +1182,13 @@ function hideButton(id){
 function change_title() {
   var teamA_text = team_chart.filters()[0] + "'s Overall Performance by ";
   var teamB_text = team_chart2.filters()[0] + "'s Overall Performance by ";
-  
+
   if (perc_view == true) teamA_text += "Games"
   else teamA_text += "Percentage"
-  
+
   if (perc_view2 == true) teamB_text += "Games"
   else teamB_text += "Percentage"
-  
+
   $('.result_year_title').text(teamA_text);
   $('.result_year_title2').text(teamB_text);
 }

--- a/web/js/cricket.js
+++ b/web/js/cricket.js
@@ -2,8 +2,17 @@ var small_chart_height = 250;
 var medium_chart_height = 500;
 var large_chart_height = 650;
 var small_width = 320; //544
-var medium_width = 720; //768
-var result_chart_width = 660;
+var medium_width = 540; //768
+var default_large_width = 660;
+var original_result_chart_width = 425;
+var result_chart_width = 540;
+var resize = .45;
+var result_chart_width = function(d){
+  var w =   $(window).outerWidth() * resize;
+  if ($(window).outerWidth() < 970) return default_large_width;
+  if (w < original_result_chart_width) return original_result_chart_width;
+  else return w;
+}
 var valueAccessor = function (d) {return d.Value < 1 ? 0 : d.Value};
 var our_colors = ["#9df5e7","#b2bfdb","#a1eda1","#fc9898", "#afedf0","#afede1", "#fc6565"];
 var team_default = d3.scale.ordinal().range(["#015B64"]);
@@ -15,7 +24,8 @@ var default_colors = d3.scale.ordinal().range(our_colors);
 var donut_inner = 40
 var donut_outer = 80
 var donut_height = 100
-var perc_view = false;
+var perc_view = true;
+var perc_view2 = true;
 
 
 grey_undefined = function(chart) {
@@ -26,12 +36,23 @@ grey_undefined = function(chart) {
 
 var yearDom = [];
 
+//Resize the chart based on the screen size
+$( window ).resize(function() {
+  result_chart_width = function(d){
+    var w =   $(window).outerWidth() * resize;
+    if ($(window).outerWidth() < 970) return default_large_width;
+    if (w < original_result_chart_width) return original_result_chart_width;
+    else return w;
+  }
+  dc.renderAll();
+});
+
 function cleanup(d) {
-	
+  
   d.Year = d.Date.slice(-2);
   d.Year = d.Year > 16 ? 1900+parseInt(d.Year) : 2000+parseInt(d.Year);
   d.Value = 1;
-	d.properDate = new Date(d.Date.split('-')[1] + " " + d.Date.split('-')[0] + ", " + d.Year);
+  d.properDate = new Date(d.Date.split('-')[1] + " " + d.Date.split('-')[0] + ", " + d.Year);
   d.matchAgainst = d.Team + '/' + d.Opposition;
   if (d.Result != "tied") d.resultStatus = d.Team + '@' + d.Result;
 
@@ -39,7 +60,7 @@ function cleanup(d) {
 }
 
 function isOdd(num) { 
-	return num % 2;
+  return num % 2;
 }
 
 function capitalizeFirst(string) { 
@@ -107,7 +128,7 @@ function change_result_view() {
     result_year_chart.xAxis().ticks(10).tickFormat(d3.format("d"));
   
   if (perc_view == false) {
-    $('.result_year_title').text("Overall Team Performance by Games");
+    $('.result_year_title').text("Overall Team A Performance by Games");
     result_year_chart
       .label(function(d) { return d; })
       .title(function(d) {
@@ -116,11 +137,12 @@ function change_result_view() {
           });
           return d.key+": "+d3.format(',')(d.value[this.layer])+" ("+this.layer+")";
       })
-      .brushOn(true);
+      .brushOn(false);
   }
   else {
-    $('.result_year_title').text("Overall Team Performance by Percentage");
+    $('.result_year_title').text("Overall Team A Performance by Percentage");
     result_year_chart = dc.lineChart('#result_year')
+      .dotRadius(10)
       .group(result_year_group, "won")
       .valueAccessor(function(d){
         var v = parseFloat(d.value["won"]/(d.value["won"]+d.value["lost"]+d.value["tied"]));
@@ -181,12 +203,13 @@ function change_result_view() {
           }
           else{
             d3.select(this)
+              .attr("r", 5.5)
               .attr("visibility", "visible")
               .on("mouseover", function(d) {
                 d3.select(this)
                   .attr("visibility", "visible")
                   .attr("r", 5.5)
-                  .style("fill", "black");
+                  .style("fill", d.color);
               })                  
               .on("mouseout", function(d) {
                 d3.select(this)
@@ -224,6 +247,188 @@ function change_result_view() {
   result_year_chart.filterAll();
   dc.renderAll();
   perc_view = !perc_view;
+}
+
+function change_result_view2() {
+  result_year_chart2 = dc.barChart('#result_year2')
+      .group(result_year_group2, "won")
+      .valueAccessor(function(d){return d.value["won"]})
+      .stack(result_year_group2, "lost", function(d) { return d.value["lost"] })
+      .stack(result_year_group2, "tied", function(d) { return d.value["tied"] })
+      .dimension(result_year)
+      .centerBar(true)
+      .height(medium_chart_height/2)
+      .width(result_chart_width)
+      .colors(d3.scale.ordinal().domain(["won", "lost", "tied"]).range(["#45936E","#92332F", "#3E70A1"]))
+      .x(d3.scale.linear().domain([1995, 2016]))
+      .elasticX(false)
+      .elasticY(true)
+      .transitionDuration(200)
+      .mouseZoomable(false)
+      .yAxisLabel("Games")
+      .renderHorizontalGridLines(true)
+      .renderVerticalGridLines(true)  
+      .margins({top: 10, right: 50, bottom: 30, left: 50})
+      .on("renderlet.result_year", function (chart) {
+          //Check if labels exist
+          var gLabels = chart.select(".labels");
+          if (gLabels.empty()){
+            gLabels = chart.select(".chart-body").append('g').classed('labels', true);
+          }
+
+          var gLabelsData = gLabels.selectAll("text").data(chart.selectAll(".bar")[0]);
+
+          gLabelsData.exit().remove(); //Remove unused elements
+
+          gLabelsData.enter().append("text") //Add new elements
+
+          gLabelsData
+            .attr('text-anchor', 'middle  ')
+            .attr('fill', 'white')
+            .attr("font-size", "11px")
+            .text(function(d){
+              return d3.select(d).data()[0].y
+            })
+            .attr('x', function(d){ 
+              return +d.getAttribute('x') + (d.getAttribute('width')/2); 
+            })
+            .attr('y', function(d){ return +d.getAttribute('y') + 15; })
+            .attr('style', function(d){
+              if (+d.getAttribute('height') < 18) return "display:none";
+            });
+        })
+        .on("preRedraw", function (chart) {
+            chart.rescale();
+        })
+        .on("preRender", function (chart) {
+            chart.rescale();
+        })
+        .on("pretransition", function (chart) {
+            chart.rescale();
+        });
+
+    result_year_chart2.xAxis().ticks(10).tickFormat(d3.format("d"));
+  
+  if (perc_view2 == false) {
+    $('.result_year_title2').text("Overall Team B Performance by Games");
+    result_year_chart2
+      .label(function(d) { return d; })
+      .title(function(d) {
+        d3.selectAll("rect.bar")
+          .on('mouseover', function(d){
+          });
+          return d.key+": "+d3.format(',')(d.value[this.layer])+" ("+this.layer+")";
+      })
+      .brushOn(false);
+  }
+  else {
+    $('.result_year_title2').text("Overall Team B Performance by Percentage");
+    result_year_chart2 = dc.lineChart('#result_year2')
+      .dotRadius(10)
+      .group(result_year_group2, "won")
+      .valueAccessor(function(d){
+        var v = parseFloat(d.value["won"]/(d.value["won"]+d.value["lost"]+d.value["tied"]));
+        if (isNaN(v)) return 0;
+        return parseFloat((v*100).toFixed(1));
+      })
+      .stack(result_year_group2, "lost", function(d) { 
+        var v = parseFloat(d.value["lost"]/(d.value["won"]+d.value["lost"]+d.value["tied"]));
+        if (isNaN(v)) return 0;
+        return parseFloat((v*100).toFixed(1));
+      })
+      .stack(result_year_group2, "tied", function(d) { 
+      if (d.value["tied"] == 0) return 0
+      else 
+        var v = parseFloat(d.value["tied"] /(d.value["won"]+d.value["lost"]+d.value["tied"])) 
+        if (isNaN(v)) return 0;
+        return parseFloat((v*100).toFixed(1));
+      })
+      .label(function(d) { return d; })
+      .title(function(d) {
+        var v = 0;
+        if (this.layer == "won") 
+          v = parseFloat(d.value["won"]/(d.value["won"]+d.value["lost"]+d.value["tied"]));
+        else if(this.layer == "lost") 
+          v = parseFloat(d.value["lost"]/(d.value["won"]+d.value["lost"]+d.value["tied"]));
+        else 
+          v = parseFloat(d.value["tied"] /(d.value["won"]+d.value["lost"]+d.value["tied"]))
+        if (isNaN(v)) v = 0;
+        else v = parseFloat((v*100).toFixed(1));
+      
+        if(d.value[this.layer] > 0){
+          d3.select(".area").selectAll("circle.dot").attr("r", 10);
+        }
+        return d.key+": "+d3.format(',')(d.value[this.layer])+" games ("+this.layer+")\nPercentage: " + v + "%"; 
+        
+      })
+      .brushOn(false)
+      .renderArea(true)
+      .dimension(result_year)
+      .height(medium_chart_height/2)
+      .width(result_chart_width)
+      .colors(d3.scale.ordinal().domain(["won", "lost", "tied"]).range(["#45936E","#92332F", "#3E70A1"]))
+      .x(d3.scale.linear().domain([1996, 2015]))
+      .y(d3.scale.linear().domain([0, 110]))
+      .elasticX(false)
+      .elasticY(false)
+      .transitionDuration(200)
+      .yAxisLabel("Games")
+      .renderHorizontalGridLines(true)
+      .renderVerticalGridLines(true)
+      .mouseZoomable(false)
+      .margins({top: 20, right: 50, bottom: 30, left: 50})
+      .on("pretransition", stackChartTransition = function (chart) {
+        chart.selectAll("circle.dot").each(function(d, i){
+          if(d.y == 0){
+            d3.select(this)
+              .attr("visibility", "hidden");
+          }
+          else{
+            d3.select(this)
+              .attr("r", 5.5)
+              .attr("visibility", "visible")
+              .on("mouseover", function(d) {
+                d3.select(this)
+                  .attr("visibility", "visible")
+                  .attr("r", 5.5)
+                  .style("fill", d.color);
+              })                  
+              .on("mouseout", function(d) {
+                d3.select(this)
+                  .attr("visibility", "visible")
+                  .attr("r", 5.5)
+                  .style("fill", d.color);
+              });
+          }
+        });
+        chart.selectAll(".line").each(function(d, i){
+          try {
+            if(d.values[i].y == 0){
+              d3.select(this)
+                .attr("visibility", "hidden");
+            }
+            else{
+              d3.select(this)
+                .attr("visibility", "hidden");
+            }
+          }
+          catch (e){
+          }
+
+        });
+        chart.rescale();
+      });
+
+    result_year_chart2.xAxis().ticks(10).tickFormat(d3.format("d"));
+  }
+  
+  result_year_chart2.yAxis().ticks(5).tickFormat(d3.format("g"));
+  grey_undefined(result_year_chart);
+  
+  //Need to reset the filter when the view changes or else, filter lingers
+  result_year_chart2.filterAll();
+  dc.renderAll();
+  perc_view2 = !perc_view2;
   
 }
 
@@ -238,10 +443,10 @@ function showCharts(err, data) {
   _data = [];
 
   for (i in data) {
-		data[i] = cleanup(data[i]);
+    data[i] = cleanup(data[i]);
   }
   _data = data;
-//	console.log(data);
+//  console.log(data);
 
   function configureableReduce(field, value, init) {
     return {
@@ -258,42 +463,77 @@ function showCharts(err, data) {
       }
     }
   }
-	
-	resultByYear = configureableReduce("Result", "Value", {
-		"won":0,
-		"lost":0,
-		"tied":0
-	});
-	
+  
+  resultByYear = configureableReduce("Result", "Value", {
+    "won":0,
+    "lost":0,
+    "tied":0
+  });
+  
     
-	//---------------------------------FILTERS-----------------------------------------
+  //---------------------------------FILTERS-----------------------------------------
   ndx = crossfilter(_data);
+  ndx2 = crossfilter(_data);
   //---------------------------ORDINARY CHARTS --------------------------------------
-	year = ndx.dimension(function(d){return d.Year});
-		
-  year_group = year.group().reduceSum(function(d){return d.Value});	
-		
-	year_chart = dc.rowChart('#year')
+  year = ndx.dimension(function(d){return d.Year});
+  year2 = ndx2.dimension(function(d){return d.Year});
+  
+  opposition = ndx.dimension(function(d){return d.Opposition});
+  opposition2 = ndx2.dimension(function(d){return d.Opposition});
+  
+  team = ndx.dimension(function(d){return d.Team});
+  team2 = ndx2.dimension(function(d){return d.Team});
+  
+  result = ndx.dimension(function(d){return d.Result});
+  result2 = ndx2.dimension(function(d){return d.Result});
+  
+  resultStatus = ndx.dimension(function(d) {return d.resultStatus});
+  resultStatus2 = ndx.dimension(function(d) {return d.resultStatus});
+  
+  year_group = year.group().reduceSum(function(d){return d.Value}); 
+  year_group2 = year2.group().reduceSum(function(d){return d.Value}); 
+    
+  opposition_group = opposition.group().reduceSum(function(d){return d.Value}); 
+  opposition_group2 = opposition2.group().reduceSum(function(d){return d.Value});
+  
+  team_group = team.group().reduceSum(function(d){return d.Value});
+  team_group2 = team2.group().reduceSum(function(d){return d.Value}); 
+    
+  result_pie_group = result.group().reduceSum(function(d){return d.Value});
+  result_pie_group2 = result2.group().reduceSum(function(d){return d.Value});
+  
+  result_year_group = year.group().reduce(resultByYear.add, resultByYear.remove, resultByYear.init);
+  
+  result_year_group2 = year2.group().reduce(resultByYear.add, resultByYear.remove, resultByYear.init);
+  
+  result_group = resultStatus.group().reduceSum(function(d){
+    if (d.Result != 'tied') return d.Value;
+    else return 0;
+  });
+  
+  result_group2 = resultStatus2.group().reduceSum(function(d){
+    if (d.Result != 'tied') return d.Value;
+    else return 0;
+  });
+  
+  
+  year_chart = dc.rowChart('#year')
     .dimension(year)
     .group(year_group)
     .colors(year_default)
     .transitionDuration(200)
     .height(large_chart_height/1.5)
-		.width(small_width)
+    .width(small_width)
     .ordering(function(d){ return -d.key })
-//		.x(d3.scale.linear().domain([-25, 25]))
+//    .x(d3.scale.linear().domain([-25, 25]))
     .elasticX(true);
-	
-	year_chart.xAxis().ticks(10).tickFormat(d3.format("g"));
-	grey_undefined(year_chart);
-
-  year_bar = ndx.dimension(function(d){return d.Year});
-    
-  year_bar_group = year_bar.group().reduceSum(function(d){return d.Value}); 
-	
-	year_bar_chart = dc.barChart('#year-bar')
-      .dimension(year_bar)
-      .group(year_bar_group)
+  
+  year_chart.xAxis().ticks(10).tickFormat(d3.format("g"));
+  grey_undefined(year_chart);
+  
+  year_bar_chart = dc.barChart('#year-bar')
+      .dimension(year)
+      .group(year_group)
       .colors(default_colors)
       .transitionDuration(200)
       .height(medium_chart_height)
@@ -303,35 +543,59 @@ function showCharts(err, data) {
       .brushOn(true)
       .elasticY(true)
       .elasticX(true);
-	
-	year_bar_chart.xAxis().ticks(5).tickFormat(d3.format("g"));
-	grey_undefined(year_bar_chart);
-		
-	opposition = ndx.dimension(function(d){return d.Opposition});
-		
-  opposition_group = opposition.group().reduceSum(function(d){return d.Value});	
-		
-	opposition_chart = dc.rowChart('#opposition')
+  
+  year_bar_chart.xAxis().ticks(5).tickFormat(d3.format("g"));
+  grey_undefined(year_bar_chart);
+    
+  
+    
+  opposition_chart = dc.rowChart('#opposition')
     .dimension(opposition)
     .group(opposition_group)
     .colors(lost_default)
     .transitionDuration(200)
     .height(small_chart_height)
-		.width(small_width-50)
+    .width(small_width-50)
     .ordering(function(d){ return -d.key })
-//		.xAxisLabel('Total Games')
-//		.xAxisPadding(500)
+//    .xAxisLabel('Total Games')
+//    .xAxisPadding(500)
     .elasticX(true)
+    .label(function(d){
+      var label = d.key + ": " + d.value;
+      return label;
+    })
     .title(function(d){
       var title = d.key + " \nTotal Games Won Against Team A: " + d.value;
       return title;
     });
-	
-	opposition_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
-	grey_undefined(opposition_chart);
-	
-	team = ndx.dimension(function(d){return d.Team});
-  team_group = team.group().reduceSum(function(d){return d.Value}); 
+  
+  opposition_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
+  grey_undefined(opposition_chart);
+  
+  opposition_chart2 = dc.rowChart('#opposition2')
+    .dimension(opposition2)
+    .group(opposition_group2)
+    .colors(lost_default)
+    .transitionDuration(200)
+    .height(small_chart_height)
+    .width(small_width-50)
+    .ordering(function(d){ return -d.key })
+//    .xAxisLabel('Total Games')
+//    .xAxisPadding(500)
+    .elasticX(true)
+    .label(function(d){
+      var label = d.key + ": " + d.value;
+      return label;
+    })
+    .title(function(d){
+      var title = d.key + " \nTotal Games Won Against Team A: " + d.value;
+      return title;
+    });
+  
+  opposition_chart2.xAxis().ticks(5).tickFormat(d3.format("d"));
+  grey_undefined(opposition_chart2);
+  
+  
     
   team_chart = dc.rowChart('#team')
     .dimension(team)
@@ -342,31 +606,52 @@ function showCharts(err, data) {
     .width(small_width-50)
     .ordering(function(d){ return -d.key })
     .elasticX(true)
+    .label(function(d){
+      var label = d.key + ": " + d.value;
+      return label;
+    })
     .title(function(d){
-      var title = d.key + " \nTotal Games Won Against Team B: " + d.value;
+      var title = d.key + " \nTotal Games Won Against Opposition: " + d.value;
       return title;
     });
   
   team_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
-  grey_undefined(team_chart); 
-	
-	result = ndx.dimension(function(d){return d.Result});
-		
-  result_group = result.group().reduceSum(function(d){return d.Value});	
-		
-	result_chart = dc.pieChart('#result')
+  grey_undefined(team_chart);
+  
+  team_chart2 = dc.rowChart('#team2')
+    .dimension(team2)
+    .group(team_group2)
+    .colors(won_default)
+    .transitionDuration(200)
+    .height(small_chart_height)
+    .width(small_width-50)
+    .ordering(function(d){ return -d.key })
+    .elasticX(true)
+    .label(function(d){
+      var label = d.key + ": " + d.value;
+      return label;
+    })
+    .title(function(d){
+      var title = d.key + " \nTotal Games Won Against Opposition: " + d.value;
+      return title;
+    });
+  
+  team_chart2.xAxis().ticks(5).tickFormat(d3.format("d"));
+  grey_undefined(team_chart2);
+    
+  result_chart = dc.pieChart('#result')
     .dimension(result)
-    .group(result_group)
+    .group(result_pie_group)
     .transitionDuration(200)
     .legend(dc.legend().x(0).y(25).itemHeight(18).gap(5))
     .height(small_chart_height-50)
     .title(function(d) {
       var title = capitalizeFirst(d.key) + ": " + d.value;
       if (d.key == "won"){
-        return "Team A Won Against Team B\n" + title;
+        return "Team A Won Against Opposition\n" + title;
       }
       else if (d.key == "lost"){
-        return "Team A Lost Against Team B\n" + title;
+        return "Team A Lost Against Opposition\n" + title;
       }
       return title;
     })
@@ -380,32 +665,63 @@ function showCharts(err, data) {
     .colors(d3.scale.ordinal().domain(["won", "lost", "tied"])
                               .range(["#45936E","#92332F", "#3E70A1"]))
     .colorAccessor(function(d) {
-			if (d.key == "won") return "won";
-			else if (d.key == "lost") return "lost";
-			return "tied";
-		});
-	
-	result_year = ndx.dimension(function(d){return d.Year});
-	result_year_group = result_year.group().reduce(resultByYear.add, resultByYear.remove, resultByYear.init);
-	
-  change_result_view();
-	
+      if (d.key == "won") return "won";
+      else if (d.key == "lost") return "lost";
+      return "tied";
+    });
+  
+  result_chart2 = dc.pieChart('#result2')
+    .dimension(result2)
+    .group(result_pie_group2)
+    .transitionDuration(200)
+    .legend(dc.legend().x(0).y(25).itemHeight(18).gap(5))
+    .height(small_chart_height-50)
+    .title(function(d) {
+      var title = capitalizeFirst(d.key) + ": " + d.value;
+      if (d.key == "won"){
+        return "Team A Won Against Opposition\n" + title;
+      }
+      else if (d.key == "lost"){
+        return "Team B Lost Against Opposition\n" + title;
+      }
+      return title;
+    })
+    .height(medium_chart_height/2)
+    .label(function(d) {
+      if (d.key == "won") return "Won: " + d.value;
+      else if (d.key == "lost") return "Lost: " + d.value;
+      return capitalizeFirst(d.key) + ": " + d.value;
+    })
+    .radius(donut_outer)
+    .colors(d3.scale.ordinal().domain(["won", "lost", "tied"])
+                              .range(["#45936E","#92332F", "#3E70A1"]))
+    .colorAccessor(function(d) {
+      if (d.key == "won") return "won";
+      else if (d.key == "lost") return "lost";
+      return "tied";
+    });
+  
   var all = ndx.groupAll();
   data_count_chart = dc.dataCount('#data_count')
     .dimension(ndx)
     .group(all)
     .html({
         some: '<span class=\'data-count\'><strong>%filter-count</strong> selected out of <strong>%total-count</strong> records</span>' +
-            ' | <a class=\'reset\' href=\'javascript:dc.filterAll(); dc.redrawAll();\'\'>Reset All</a>',
+            ' | <a class=\'reset\' href=\'javascript:team_chart.filterAll(); opposition_chart.filterAll(); result_chart.filterAll(); dc.redrawAll();\'\'>Reset All</a>',
         all: '<span class=\'data-count\'>All records selected. Please click on the graph to apply filters.<span>'
     });
-	
+  
+  var all2 = ndx2.groupAll();
+  data_count_chart2 = dc.dataCount('#data_count2')
+    .dimension(ndx2)
+    .group(all2)
+    .html({
+        some: '<span class=\'data-count\'><strong>%filter-count</strong> selected out of <strong>%total-count</strong> records</span>' +
+            ' | <a class=\'reset\' href=\'javascript:team_chart2.filterAll(); opposition_chart2.filterAll(); result_chart2.filterAll(); dc.redrawAll();\'\'>Reset All</a>',
+        all: '<span class=\'data-count\'>All records selected. Please click on the graph to apply filters.<span>'
+    });
+  
   //pyramid chart
-  resultStatus = ndx.dimension(function(d) {return d.resultStatus});
-  result_group = resultStatus.group().reduceSum(function(d){
-    if (d.Result != 'tied') return d.Value;
-    else return 0;
-  })
   
   team_opp_chart = dc.pyramidChart('#team_opp')
     .dimension(resultStatus)
@@ -434,18 +750,23 @@ function showCharts(err, data) {
     .transitionDuration(200);
   
   team_opp_chart.xAxis().ticks(7).tickFormat(function(x) {return d3.format('s')(Math.abs(x))})
-	
-	dc.renderAll();
-
+  
+  dc.renderAll();
+  
   initialize();
 };
 
 function initialize(){
   //odd are wins, even are losses
-  var a = $('#team_opp g .row text:eq(7)'); 
+//  var a = $('#team_opp g .row text:eq(7)'); 
+  var a = $('#team g.row text:eq(3)');
+  var b = $('#team2 g.row text:eq(0)');
 //  var b = $('#team_opp g .row rect:eq(6)');
   
   a.simulate('click');
+  b.simulate('click');
+  change_result_view();
+  change_result_view2();
 //  b.simulate('click');
   
 };
@@ -456,7 +777,7 @@ function hideshow(id){
 };
 
 function showAll() {
-  var idList = ["#result_year", "#team_opp", "#result", "#team", "#opposition"]
+  var idList = ["#result_year", "#team_opp", "#result", "#team", "#opposition", "#result_year2", "#team_opp2", "#result2", "#team2", "#opposition2"]
   
   for (x in idList) {
     var a = $(idList[x]);

--- a/web/js/cricket.js
+++ b/web/js/cricket.js
@@ -4,14 +4,15 @@ var large_chart_height = 650;
 var small_width = 320; //544
 var medium_width = 540; //768
 var default_large_width = 660;
-var original_result_chart_width = 425;
-var result_chart_width = 540;
-var resize = .45;
+var original_result_chart_width = 500;
+var resize = .425;
 var result_chart_width = function(d){
-  var w =   $(window).outerWidth() * resize;
-  if ($(window).outerWidth() < 970) return default_large_width;
+  var windowWidth = $(window).width();
+  var w =   windowWidth * resize;
+  if (windowWidth <= 972) return default_large_width;
   if (w < original_result_chart_width) return original_result_chart_width;
-  else return w;
+  if (windowWidth >1080) return original_result_chart_width+100;
+  return w;
 }
 var valueAccessor = function (d) {return d.Value < 1 ? 0 : d.Value};
 var our_colors = ["#9df5e7","#b2bfdb","#a1eda1","#fc9898", "#afedf0","#afede1", "#fc6565"];
@@ -39,10 +40,12 @@ var yearDom = [];
 //Resize the chart based on the screen size
 $( window ).resize(function() {
   result_chart_width = function(d){
-    var w =   $(window).outerWidth() * resize;
-    if ($(window).outerWidth() < 970) return default_large_width;
+    var windowWidth = $(window).width();
+    var w =   windowWidth * resize;
+    if (windowWidth <= 972) return default_large_width;
     if (w < original_result_chart_width) return original_result_chart_width;
-    else return w;
+    if (windowWidth >1080) return original_result_chart_width+100;
+    return w;
   }
   dc.renderAll();
 });

--- a/web/js/cricket.js
+++ b/web/js/cricket.js
@@ -71,6 +71,7 @@ function capitalizeFirst(string) {
 }
 
 function change_result_view() {
+  change_title();
   result_year_chart = dc.barChart('#result_year')
       .group(result_year_group, "won")
       .valueAccessor(function(d){return d.value["won"]})
@@ -131,7 +132,6 @@ function change_result_view() {
     result_year_chart.xAxis().ticks(10).tickFormat(d3.format("d"));
   
   if (perc_view == false) {
-    $('.result_year_title').text("Overall Team A Performance by Games");
     result_year_chart
       .label(function(d) { return d; })
       .title(function(d) {
@@ -143,7 +143,6 @@ function change_result_view() {
       .brushOn(false);
   }
   else {
-    $('.result_year_title').text("Overall Team A Performance by Percentage");
     result_year_chart = dc.lineChart('#result_year')
       .dotRadius(10)
       .group(result_year_group, "won")
@@ -313,7 +312,6 @@ function change_result_view2() {
     result_year_chart2.xAxis().ticks(10).tickFormat(d3.format("d"));
   
   if (perc_view2 == false) {
-    $('.result_year_title2').text("Overall Team B Performance by Games");
     result_year_chart2
       .label(function(d) { return d; })
       .title(function(d) {
@@ -325,7 +323,6 @@ function change_result_view2() {
       .brushOn(false);
   }
   else {
-    $('.result_year_title2').text("Overall Team B Performance by Percentage");
     result_year_chart2 = dc.lineChart('#result_year2')
       .dotRadius(10)
       .group(result_year_group2, "won")
@@ -564,13 +561,24 @@ function showCharts(err, data) {
 //    .xAxisPadding(500)
     .elasticX(true)
     .label(function(d){
-      var label = d.key + ": " + d.value;
-      return label;
+      var label = d.key;
+      if($.inArray(d.key, team_chart.filters()) == 0) return "";
+      return label + ": " + d.value;
     })
     .title(function(d){
-      var title = d.key + " \nTotal Games Lost Against Team A: " + d.value;
+      if($.inArray(d.key, team_chart.filters()) == -1) return;
+      var title = d.key + " \nTotal Games Against Team A: " + d.value;
       return title;
     });
+  
+  opposition_chart._onClick = function(d) {
+      if($.inArray(d.key, team_chart.filters()) == 0) return;
+      var filter = opposition_chart.keyAccessor()(d);
+        dc.events.trigger(function () {
+            opposition_chart.filter(filter);
+            opposition_chart.redrawGroup();
+        });
+   }
   
   opposition_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(opposition_chart);
@@ -587,13 +595,24 @@ function showCharts(err, data) {
 //    .xAxisPadding(500)
     .elasticX(true)
     .label(function(d){
-      var label = d.key + ": " + d.value;
-      return label;
+      var label = d.key;
+      if($.inArray(d.key, team_chart2.filters()) == 0) return "";
+      return label + ": " + d.value;
     })
     .title(function(d){
-      var title = d.key + " \nTotal Games Lost Against Team A: " + d.value;
+      if($.inArray(d.key, team_chart2.filters()) == -1) return;
+      var title = d.key + " \nTotal Games Against Team B: " + d.value;
       return title;
     });
+  
+  opposition_chart2._onClick = function(d) {
+      if($.inArray(d.key, team_chart2.filters()) == 0) return;
+      var filter = opposition_chart2.keyAccessor()(d);
+        dc.events.trigger(function () {
+            opposition_chart2.filter(filter);
+            opposition_chart2.redrawGroup();
+        });
+   }
   
   opposition_chart2.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(opposition_chart2);
@@ -605,18 +624,29 @@ function showCharts(err, data) {
     .group(team_group)
     .colors(won_default)
     .transitionDuration(200)
+    .filter('Australia')
     .height(small_chart_height)
     .width(small_width-50)
     .ordering(function(d){ return -d.key })
     .elasticX(true)
     .label(function(d){
-      var label = d.key + ": " + d.value;
+      var label = d.key;
+      if($.inArray(d.key, team_chart.filters()) == 0) return label + ": " + d.value;
       return label;
     })
     .title(function(d){
-      var title = d.key + " \nTotal Games Won Against Opposition: " + d.value;
+      if($.inArray(d.key, team_chart.filters()) == -1) return;
+      var title = d.key + " \nTotal Games Against Opposition(s): " + d.value;
       return title;
     });
+  
+  team_chart._onClick = function(d) {
+      dc.events.trigger(() => {
+        team_chart.replaceFilter(d.key);
+        team_chart.redrawGroup()
+      });
+      hideButton('#teamA');
+   }
   
   team_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(team_chart);
@@ -626,18 +656,29 @@ function showCharts(err, data) {
     .group(team_group2)
     .colors(won_default)
     .transitionDuration(200)
+    .filter('New Zealand')
     .height(small_chart_height)
     .width(small_width-50)
     .ordering(function(d){ return -d.key })
     .elasticX(true)
     .label(function(d){
-      var label = d.key + ": " + d.value;
+      var label = d.key;
+      if($.inArray(d.key, team_chart2.filters()) == 0) return label + ": " + d.value;
       return label;
     })
     .title(function(d){
-      var title = d.key + " \nTotal Games Won Against Opposition: " + d.value;
+      if($.inArray(d.key, team_chart2.filters()) == -1) return;
+      var title = d.key + " \nTotal Games Against Opposition(s): " + d.value;
       return title;
     });
+  
+  team_chart2._onClick = function(d) {
+      dc.events.trigger(() => {
+        team_chart2.replaceFilter(d.key);
+        team_chart2.redrawGroup()
+      });
+      hideButton('#teamB');
+   }
   
   team_chart2.xAxis().ticks(5).tickFormat(d3.format("d"));
   grey_undefined(team_chart2);
@@ -682,7 +723,7 @@ function showCharts(err, data) {
     .title(function(d) {
       var title = capitalizeFirst(d.key) + ": " + d.value;
       if (d.key == "won"){
-        return "Team A Won Against Opposition\n" + title;
+        return "Team B Won Against Opposition\n" + title;
       }
       else if (d.key == "lost"){
         return "Team B Lost Against Opposition\n" + title;
@@ -760,18 +801,10 @@ function showCharts(err, data) {
 };
 
 function initialize(){
-  //odd are wins, even are losses
-//  var a = $('#team_opp g .row text:eq(7)'); 
-  var a = $('#team g.row text:eq(3)');
-  var b = $('#team2 g.row text:eq(0)');
-//  var b = $('#team_opp g .row rect:eq(6)');
-  
-  a.simulate('click');
-  b.simulate('click');
   change_result_view();
   change_result_view2();
-//  b.simulate('click');
-  
+  hideButton("#teamA");
+  hideButton("#teamB");
 };
 
 function hideshow(id){
@@ -790,3 +823,26 @@ function showAll() {
   }
   $('[type=checkbox]').prop('checked', true); 
 };
+
+function hideButton(id){
+  if (id == "#teamA" && $.inArray("Australia", team_chart.filters()) == 0) {
+    $(id).hide();
+  }
+  if (id == "#teamB" && $.inArray("New Zealand", team_chart2.filters()) == 0) {
+    $(id).hide();
+  }
+}
+
+function change_title() {
+  var teamA_text = team_chart.filters()[0] + "'s Overall Performance by ";
+  var teamB_text = team_chart2.filters()[0] + "'s Overall Performance by ";
+  
+  if (perc_view == false) teamA_text += "Games"
+  else teamA_text += "Percentage"
+  
+  if (perc_view2 == false) teamB_text += "Games"
+  else teamB_text += "Percentage"
+  
+  $('.result_year_title').text(teamA_text);
+  $('.result_year_title2').text(teamB_text);
+}

--- a/web/js/cricket.js
+++ b/web/js/cricket.js
@@ -646,6 +646,7 @@ function showCharts(err, data) {
         team_chart.redrawGroup()
       });
       hideButton('#teamA');
+      change_title();
    }
   
   team_chart.xAxis().ticks(5).tickFormat(d3.format("d"));
@@ -678,6 +679,7 @@ function showCharts(err, data) {
         team_chart2.redrawGroup()
       });
       hideButton('#teamB');
+      change_title();
    }
   
   team_chart2.xAxis().ticks(5).tickFormat(d3.format("d"));

--- a/web/js/cricket.js
+++ b/web/js/cricket.js
@@ -565,7 +565,7 @@ function showCharts(err, data) {
       return label;
     })
     .title(function(d){
-      var title = d.key + " \nTotal Games Won Against Team A: " + d.value;
+      var title = d.key + " \nTotal Games Lost Against Team A: " + d.value;
       return title;
     });
   
@@ -588,7 +588,7 @@ function showCharts(err, data) {
       return label;
     })
     .title(function(d){
-      var title = d.key + " \nTotal Games Won Against Team A: " + d.value;
+      var title = d.key + " \nTotal Games Lost Against Team A: " + d.value;
       return title;
     });
   

--- a/web/stylesheets/styles.css
+++ b/web/stylesheets/styles.css
@@ -1,6 +1,6 @@
 .dc-chart g.row text {
   fill: whitesmoke;
-	font-size: 12px;
+  font-size: 12px;
 }
 
 .dc-chart g.row text.row.dim {
@@ -9,7 +9,7 @@
 
 .dc-chart .selected path {
     stroke-width: 0;
-    stroke: #ccc;
+/*    stroke: #ccc;*/
     fill-opacity: 1;
 }
 
@@ -27,18 +27,22 @@
 }
 
 .dc-chart .pie-slice {
-  fill: white;
+  fill: black;
 }
 
 .grey {
   opacity: 0.2;
 }
 
+.deselected {
+  opacity: 0.4;
+}
+
 .dot {
   stroke-width: 8;
   opacity: 1;
-  fill-opacity: 0.5 !important;
-  stroke-opacity: 0.5 !important;
+  fill-opacity: 0.8 !important;
+  stroke-opacity: 0.8 !important;
 }
 
 .dot:hover {
@@ -80,6 +84,10 @@ body {
 .no-bullets{
   list-style-type: none;
   padding: 0;
+}
+
+.no-bullets li {
+  margin-bottom: 5px;
 }
 
 .sidebar {
@@ -146,5 +154,21 @@ body {
 }
 
 .dc-chart path.area {
-  fill-opacity: 0.6;
+  fill-opacity: 0.8;
+}
+
+.left-team {
+  
+}
+
+.right-team {
+
+}
+
+input[type="checkbox"] {
+  margin-right: 20px; 
+}
+
+.dc-chart rect.deselected ~ text {
+  opacity: 0.5;
 }

--- a/web/views/cricket.html
+++ b/web/views/cricket.html
@@ -63,54 +63,73 @@
         </div>
       </div>
     </div>
-		<div class="tab-content">
-			<div id="summary" class="tab-pane fade in active">
-				<div class="container">
-					<div class="row"><!-- start first row -->
-						<div class="col-md-12">
-							<div class="row">
-									<div class="col-md-12" id="result_year">
-										Win, Loss and Ties By Team(s) Selected
-									</div>
-							</div>
-							<div class="row">
-									<div class="col-md-6" id="opposition">
-											Total Games by Teams
-											<legend><a href='javascript:opposition_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
-									</div>
-									<div class="col-md-6" id="result">
-										Match Results
-										<legend><a href='javascript:result_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
-									</div>
-							</div>
-						</div>
-					</div><!-- end of first row -->
-				</div>
-			</div>
-			<div id="game_per" class="tab-pane fade">
-				<div class="container">
-					<div class="row"><!-- start first row -->
-						<div class="col-md-12">
-							<div class="row">
-									<div class="col-md-12" id="result_year">
-										Win, Loss and Ties By Team(s) Selected
-									</div>
-							</div>
-							<div class="row">
-									<div class="col-md-6" id="opposition">
-											Total Games by Teams
-											<legend><a href='javascript:opposition_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
-									</div>
-									<div class="col-md-6" id="result">
-										Match Results2
-										<legend><a href='javascript:result_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
-									</div>
-							</div>
-						</div>
-					</div><!-- end of first row -->
-				</div>
-			</div>
-		</div>
+		
+    <div class="tab-content">
+      <div id="summary" class="tab-pane fade in active">
+        <div class="container">
+          <div class="row"><!-- start first row -->
+            <div class="col-md-6 left-team">
+              <div class="col-md-12 col-xs-10" id='data_count' style='padding: 0'>
+                <span class='filter-count'></span>
+                selected out of <span class='total-count'></span> records.
+              </div>
+              <div class="col-md-12 col-xs-10 collapse-in" id="result_year">
+                <span class="result_year_title">Win, Loss and Ties By Team(s) Selected</span> 
+                <input type='button' class='btn btn-primary btn-xs hideshow' value='change view' onclick="change_result_view()">
+                <br/>
+              </div>
+              <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="team">
+                Team A
+                <legend><a href="javascript:team_chart.filterAll(); team_chart.filter('Australia'); dc.redrawAll(); hideButton('#teamA')" class='btn btn-info pull-right reset' style='display:none;' id="teamA"><i class="fa fa-refresh"> Reset</i> </a></legend>
+              </div>
+              <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="opposition">
+                Opposition A
+                <legend><a href="javascript:opposition_chart.filterAll(); dc.redrawAll()" class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+              </div>
+              <div class="col-md-6 col-xs-4 collapse-in" id="result">
+                Match Results of Team A
+                <legend><a href='javascript:result_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
+              </div>
+<!--
+              <div class="col-md-6 col-sm-8 col-xs-10 collapse-in" id="team_opp">
+                  Win/Loss by Team
+                  <legend><a href='javascript:team_opp_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+              </div>
+-->
+            </div>
+            <div class="col-md-6 right-team">
+              <div class="col-md-12 col-xs-10" id='data_count2' style='padding: 0'>
+                <span class='filter-count'></span>
+                selected out of <span class='total-count'></span> records.
+              </div>
+              <div class="col-md-12 col-xs-10 collapse-in" id="result_year2">
+                <span class="result_year_title2">Win, Loss and Ties By Team(s) Selected</span> 
+                <input type='button' class='btn btn-primary btn-xs hideshow' value='change view' onclick="change_result_view2()">
+                <br/>
+              </div>
+              <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="team2">
+                Team B
+                <legend><a href="javascript:team_chart2.filterAll(); team_chart2.filter('New Zealand'); dc.redrawAll(); hideButton('#teamB')" class='btn btn-info pull-right reset' style='display:none;' id="teamB"><i class="fa fa-refresh"> Reset</i> </a></legend>
+              </div>
+              <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="opposition2">
+                Opposition B
+                <legend><a href='javascript:opposition_chart2.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+              </div>
+              <div class="col-md-6 col-xs-4 collapse-in" id="result2">
+                Match Results of Team B
+                <legend><a href='javascript:result_chart2.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
+              </div>
+<!--
+              <div class="col-md-6 col-sm-8 col-xs-10 collapse-in" id="team_opp">
+                  Win/Loss by Team
+                  <legend><a href='javascript:team_opp_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+              </div>
+-->
+            </div>
+          </div><!-- end of first row -->
+        </div>
+      </div>
+    </div>
     
 
 

--- a/web/views/index.twig
+++ b/web/views/index.twig
@@ -5,30 +5,53 @@
   <div id="summary" class="tab-pane fade in active">
     <div class="container">
       <div class="row"><!-- start first row -->
-        <div class="col-md-12 col-xs-10" id='data_count' style='padding: 0'>
-          <span class='filter-count'></span>
-         selected out of <span class='total-count'></span> records.
+        
+        <div class="col-md-6 left-team">
+          <div class="col-md-12 col-xs-10" id='data_count' style='padding: 0'>
+            <span class='filter-count'></span>
+            selected out of <span class='total-count'></span> records.
+          </div>
+          <div class="col-md-12 col-xs-10 collapse-in" id="result_year">
+            <span class="result_year_title">Win, Loss and Ties By Team(s) Selected</span> 
+            <input type='button' class='btn btn-primary btn-xs hideshow' value='change view' onclick="change_result_view()">
+            <br/>
+          </div>
+          <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="team">
+            Team A
+            <legend><a href='javascript:team_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+          </div>
+          <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="opposition">
+            Opposition A
+            <legend><a href='javascript:opposition_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+          </div>
+          <div class="col-md-6 col-xs-4 collapse-in" id="result">
+            Match Results of Team A
+            <legend><a href='javascript:result_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
+          </div>
         </div>
-        <div class="col-md-8 col-xs-10 collapse-in" id="result_year">
-          <span class="result_year_title">Win, Loss and Ties By Team(s) Selected</span> 
-          <input type='button' class='btn btn-primary btn-xs hideshow' value='change view' onclick="change_result_view()">
-          <br/>
-        </div>
-        <div class="col-md-4 col-xs-4 collapse-in" id="result">
-          Match Results
-          <legend><a href='javascript:result_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
-        </div>
-        <div class="col-md-6 col-sm-8 col-xs-10 collapse-in" id="team_opp">
-          Win/Loss by Team
-          <legend><a href='javascript:team_opp_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
-        </div>
-        <div class="col-md-3 col-sm-6 col-xs-6 collapse-in" id="team">
-          Team A
-          <legend><a href='javascript:team_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
-        </div>
-        <div class="col-md-3 col-sm-6 col-xs-6 collapse-in" id="opposition">
-          Team B
-          <legend><a href='javascript:opposition_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+
+        <div class="col-md-6 right-team">
+          <div class="col-md-12 col-xs-10" id='data_count2' style='padding: 0'>
+            <span class='filter-count'></span>
+            selected out of <span class='total-count'></span> records.
+          </div>
+          <div class="col-md-12 col-xs-10 collapse-in" id="result_year2">
+            <span class="result_year_title2">Win, Loss and Ties By Team(s) Selected</span> 
+            <input type='button' class='btn btn-primary btn-xs hideshow' value='change view' onclick="change_result_view2()">
+            <br/>
+          </div>
+          <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="team2">
+            Team B
+            <legend><a href='javascript:team_chart2.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+          </div>
+          <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="opposition2">
+            Opposition B
+            <legend><a href='javascript:opposition_chart2.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+          </div>
+          <div class="col-md-6 col-xs-4 collapse-in" id="result2">
+            Match Results of Team B
+            <legend><a href='javascript:result_chart2.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
+          </div>
         </div>
       </div><!-- end of first row -->
     </div>

--- a/web/views/index.twig
+++ b/web/views/index.twig
@@ -5,7 +5,6 @@
   <div id="summary" class="tab-pane fade in active">
     <div class="container">
       <div class="row"><!-- start first row -->
-        
         <div class="col-md-6 left-team">
           <div class="col-md-12 col-xs-10" id='data_count' style='padding: 0'>
             <span class='filter-count'></span>
@@ -18,18 +17,17 @@
           </div>
           <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="team">
             Team A
-            <legend><a href='javascript:team_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+            <legend><a href="javascript:team_chart.filterAll(); team_chart.filter('Australia'); dc.redrawAll(); hideButton('#teamA')" class='btn btn-info pull-right reset' style='display:none;' id="teamA"><i class="fa fa-refresh"> Reset</i> </a></legend>
           </div>
           <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="opposition">
             Opposition A
-            <legend><a href='javascript:opposition_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+            <legend><a href="javascript:opposition_chart.filterAll(); dc.redrawAll()" class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
           </div>
           <div class="col-md-6 col-xs-4 collapse-in" id="result">
             Match Results of Team A
             <legend><a href='javascript:result_chart.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i></a></legend>
           </div>
         </div>
-
         <div class="col-md-6 right-team">
           <div class="col-md-12 col-xs-10" id='data_count2' style='padding: 0'>
             <span class='filter-count'></span>
@@ -42,7 +40,7 @@
           </div>
           <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="team2">
             Team B
-            <legend><a href='javascript:team_chart2.filterAll(); dc.redrawAll()' class='btn btn-info pull-right reset' style='display:none;'><i class="fa fa-refresh"> Reset</i> </a></legend>
+            <legend><a href="javascript:team_chart2.filterAll(); team_chart2.filter('New Zealand'); dc.redrawAll(); hideButton('#teamB')" class='btn btn-info pull-right reset' style='display:none;' id="teamB"><i class="fa fa-refresh"> Reset</i> </a></legend>
           </div>
           <div class="col-md-6 col-sm-6 col-xs-6 collapse-in" id="opposition2">
             Opposition B

--- a/web/views/nav.html
+++ b/web/views/nav.html
@@ -26,29 +26,45 @@
   <div class="sidebar collapse" id="sidebar">
     <div>
       <ul class="no-bullets"><!-- class="nav navbar-nav" -->
-        <li><a><label>
-          <input type="checkbox" checked onclick="hideshow('#result_year')">
-          Overall
-          </label></a></li>
-        <li><a><label>
-          <input type="checkbox" checked onclick="hideshow('#team_opp')">
-          Win/Loss
-          </label></a></li>
-        <li><a><label>
-          <input type="checkbox" checked onclick="hideshow('#result')">
-          Match Results
-          </label></a></li>
-        <li><a><label>
-          <input type="checkbox" checked onclick="hideshow('#team')">
-          Team A
-          </label></a></li>
-        <li><a><label>
-          <input type="checkbox" checked onclick="hideshow('#opposition')">
-          Team B
-          </label></a></li>
+        <strong>Overall</strong>
+        <li>
+          <a><label>A
+            <input type="checkbox" checked onclick="hideshow('#result_year')">
+          </label></a>
+          <a><label>B
+            <input type="checkbox" checked onclick="hideshow('#result_year2')">
+          </label></a>
+        </li>
+        <strong>Team</strong>
+        <li>
+          <a><label>A
+            <input type="checkbox" checked onclick="hideshow('#team')">
+          </label></a>
+          <a><label>B
+            <input type="checkbox" checked onclick="hideshow('#team2')">
+          </label></a>
+        </li>
+        <strong>Opposition</strong>
+        <li>
+          <a><label>A
+            <input type="checkbox" checked onclick="hideshow('#opposition')">
+          </label></a>
+          <a><label>B
+            <input type="checkbox" checked onclick="hideshow('#opposition2')">
+          </label></a>
+        </li>
+        <strong>Match Results</strong>
+        <li>
+          <a><label>A
+            <input type="checkbox" checked onclick="hideshow('#result')">
+          </label></a>
+          <a><label>B
+            <input type="checkbox" checked onclick="hideshow('#result2')">
+          </label></a>
+        </li>
         <li><a onclick="showAll()"><label>
           Show All 
-          </label></a></li>
+        </label></a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Resolves #24 
This branch creates a side by side comparison of the available data
This also adds additional functionality to the onClick of the Team Charts
- One team selected at a time
  Opposition Chart
- Selected team is not displayed
  The title of the line charts are dynamic and is based on the current Team Selected
  A new dataset
- Includes NZ Captains
- This dataset might be expanded in a different issue, HOWEVER adding NZ Captains have taken longer than expected, and we might need to reconsider this as work that can be done when this project is complete.
- **_The addition of the Captains columns will be used to show how far we can take the application and to satisfy one of the questions raised during the prelim presentations - Can I pick a player and....._**
